### PR TITLE
Support OpenSSL3, fixes duplicati issue #4716

### DIFF
--- a/FasterHashing/FasterHash.cs
+++ b/FasterHashing/FasterHash.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Runtime.Remoting.Channels;
 using System.Security.Cryptography;
 
 namespace FasterHashing
@@ -24,9 +25,9 @@ namespace FasterHashing
         /// </summary>
         OpenSSL11,
         /// <summary>
-        /// Specifies using OpenSSL 3.0
+        /// Specifies using OpenSSL 3
         /// </summary>
-        OpenSSL30,
+        OpenSSL3,
         /// <summary>
         /// Specifies using CNG
         /// </summary>
@@ -94,8 +95,8 @@ namespace FasterHashing
                 case HashImplementation.OpenSSL11:
                     result = OpenSSL11HashAlgorithm.Create(algorithm);
                     break;
-                case HashImplementation.OpenSSL30:
-                    result = OpenSSL30HashAlgorithm.Create(algorithm);
+                case HashImplementation.OpenSSL3:
+                    result = OpenSSL3HashAlgorithm.Create(algorithm);
                     break;
                 case HashImplementation.CNG:
                     result = CNGHashAlgorithm.Create(algorithm, false);
@@ -140,8 +141,8 @@ namespace FasterHashing
             // Then try common names for OpenSSL
             if (new[] { "openssl", "ssleay", "ssl" }.Any(x => string.Equals(x, env)))
             {
-                if (SupportsImplementation(HashImplementation.OpenSSL30))
-                    return HashImplementation.OpenSSL30;
+                if (SupportsImplementation(HashImplementation.OpenSSL3))
+                    return HashImplementation.OpenSSL3;
                 if (SupportsImplementation(HashImplementation.OpenSSL11))
                     return HashImplementation.OpenSSL11;
                 if (SupportsImplementation(HashImplementation.OpenSSL10))
@@ -179,17 +180,17 @@ namespace FasterHashing
 
             // Finally test for OpenSSL versions, newest first
             string version = null;
-            if (string.Equals(Environment.GetEnvironmentVariable("FH_DISABLE_OPENSSL30"), "1", StringComparison.OrdinalIgnoreCase))
+            if (string.Equals(Environment.GetEnvironmentVariable("FH_DISABLE_OPENSSL3"), "1", StringComparison.OrdinalIgnoreCase))
             {
-                System.Diagnostics.Trace.WriteLine("OpenSSL 3.0 disabled, not probing");
+                System.Diagnostics.Trace.WriteLine("OpenSSL 3 disabled, not probing");
             }
             else
             {
-                version = OpenSSL30Version;
+                version = OpenSSL3Version;
                 if (version != null)
                 {
-                    System.Diagnostics.Trace.WriteLine($"Found OpenSSL 3.0 library with version string: {version}");
-                    return HashImplementation.OpenSSL30;
+                    System.Diagnostics.Trace.WriteLine($"Found OpenSSL 3 library with version string: {version}");
+                    return HashImplementation.OpenSSL3;
                 }
             }
 
@@ -246,13 +247,14 @@ namespace FasterHashing
         {
             get
             {
+                // assume LibreSSL API-compatibility with OpenSSL 1.1
                 try {
                     string version;
                     if ((version = OpenSSL11HashAlgorithm.OpenSSL_version()).Contains("OpenSSL 1.1.") ||
                          version.Contains("LibreSSL") )
                         return version;
                 }
-                catch (Exception ex) { System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL11: {ex}"); }
+                catch (Exception ex) { System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL11/ LibreSSL: {ex}"); }
 
                 return null;
             }
@@ -261,14 +263,14 @@ namespace FasterHashing
         /// <summary>
         /// Gets the version string from the installed OpenSSL 1.1 library, or null if no such library is found
         /// </summary>
-        public static string OpenSSL30Version
+        public static string OpenSSL3Version
         {
             get
             {
                 try
                 {
                     string version;
-                    if ( (version = OpenSSL30HashAlgorithm.OpenSSL_version()).Contains("OpenSSL 3."))
+                    if ( (version = OpenSSL3HashAlgorithm.OpenSSL_version()).Contains("OpenSSL 3."))
                         return version;
                 }
                 catch (Exception ex) { System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3: {ex}"); }
@@ -317,8 +319,8 @@ namespace FasterHashing
                     return OpenSSL10Version != null;
                 case HashImplementation.OpenSSL11:
                     return OpenSSL11Version != null;
-                case HashImplementation.OpenSSL30:
-                    return OpenSSL30Version != null;
+                case HashImplementation.OpenSSL3:
+                    return OpenSSL3Version != null;
                 case HashImplementation.AppleCommonCrypto:
                     return AppleCommonCryptoHashAlgorithm.IsSupported;
                 //case HashImplementation.CNG:

--- a/FasterHashing/FasterHashing.csproj
+++ b/FasterHashing/FasterHashing.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -7,10 +7,11 @@
     <OutputType>Library</OutputType>
     <RootNamespace>FasterHashing</RootNamespace>
     <AssemblyName>FasterHashing</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <ReleaseVersion>1.3.0</ReleaseVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\FasterHashing.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/FasterHashing/InteropOpenSSL.cs
+++ b/FasterHashing/InteropOpenSSL.cs
@@ -1258,9 +1258,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libssl
+    /// P/Invoke signatures for OpenSSL 3 libraries, using libssl
     /// </summary>
-    internal static class InteropOpenSSL30_libssl
+    internal static class InteropOpenSSL3_libssl
     {
         /// <summary>
         /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
@@ -1361,19 +1361,12 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);
-		
-		/// <summary>
-        /// Gets the string representation of the SSL library version
-        /// </summary>
-        /// <returns>A const long with the SSL version.</returns>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int OpenSSL_version_num();
     }
 
     /// <summary>
-    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libssl.so.3
+    /// P/Invoke signatures for OpenSSL 3 libraries, using libssl.so.3
     /// </summary>
-    internal static class InteropOpenSSL30_libssl_so_3
+    internal static class InteropOpenSSL3_libssl_so_3
     {
         /// <summary>
         /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
@@ -1474,19 +1467,12 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);
-		
-		/// <summary>
-        /// Gets the string representation of the SSL library version
-        /// </summary>
-        /// <returns>A const long with the SSL version.</returns>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int OpenSSL_version_num();
     }
 
     /// <summary>
-    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libcrypto.so
+    /// P/Invoke signatures for OpenSSL 3 libraries, using libcrypto.so
     /// </summary>
-    internal static class InteropOpenSSL30_libcrypto_so
+    internal static class InteropOpenSSL3_libcrypto_so
     {
         /// <summary>
         /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
@@ -1587,19 +1573,12 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);
-		
-		/// <summary>
-        /// Gets the string representation of the SSL library version
-        /// </summary>
-        /// <returns>A const long with the SSL version.</returns>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int OpenSSL_version_num();
     }
 
     /// <summary>
-    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libcrypto.so.3
+    /// P/Invoke signatures for OpenSSL 3 libraries, using libcrypto.so.3
     /// </summary>
-    internal static class InteropOpenSSL30_libcrypto_so_3
+    internal static class InteropOpenSSL3_libcrypto_so_3
     {
         /// <summary>
         /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
@@ -1700,245 +1679,12 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);
-		
-		/// <summary>
-        /// Gets the string representation of the SSL library version
-        /// </summary>
-        /// <returns>A const long with the SSL version.</returns>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int OpenSSL_version_num();
     }
 
     /// <summary>
-    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libssl-3.dll
+    /// P/Invoke signatures for OpenSSL 3 libraries, using libcrypto-3.dll
     /// </summary>
-    internal static class InteropOpenSSL30_libssl_3_dll
-    {
-        /// <summary>
-        /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
-        /// </summary>
-        private const string DLLNAME = "libssl-3.dll";
-
-        /// <summary>
-        /// Initializes the message digest context with the hashing method
-        /// </summary>
-        /// <returns>1 for succes or 0 for failure.</returns>
-        /// <param name="ctx">The message digest context.</param>
-        /// <param name="type">The digest type.</param>
-        /// <param name="impl">The digest implementation.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int EVP_DigestInit_ex(IntPtr ctx, IntPtr type, IntPtr impl);
-
-        /// <summary>
-        /// Processes a chunk of data, updating the message digest
-        /// </summary>
-        /// <returns>1 for succes or 0 for failure.</returns>
-        /// <param name="ctx">The message digest context.</param>
-        /// <param name="data">The data to update the digest with.</param>
-        /// <param name="cnt">The number of bytes in the buffer.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int EVP_DigestUpdate(IntPtr ctx, byte[] data, uint cnt);
-        
-        /// <summary>
-        /// Processes a chunk of data, updating the message digest
-        /// </summary>
-        /// <returns>1 for succes or 0 for failure.</returns>
-        /// <param name="ctx">The message digest context.</param>
-        /// <param name="data">The data to update the digest with.</param>
-        /// <param name="cnt">The number of bytes in the buffer.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int EVP_DigestUpdate(IntPtr ctx, IntPtr data, uint cnt);
-
-        /// <summary>
-        /// Completes the message digest
-        /// </summary>
-        /// <returns>1 for succes or 0 for failure.</returns>
-        /// <param name="ctx">The context to use.</param>
-        /// <param name="result">A buffer to contain the result.</param>
-        /// <param name="s">The length of the buffer.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int EVP_DigestFinal_ex(IntPtr ctx, byte[] result, ref uint s);
-
-        /// <summary>
-        /// Gets the digest implementation from a anme
-        /// </summary>
-        /// <returns>The digest implementation or null.</returns>
-        /// <param name="name">The name of the digets to find.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static IntPtr EVP_get_digestbyname(string name);
-
-
-        /// <summary>
-        /// Creates the message digest context
-        /// </summary>
-        /// <returns>The message digest context.</returns>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static IntPtr EVP_MD_CTX_new();
-
-        /// <summary>
-        /// Resets the message digest context
-        /// </summary>
-        /// <returns>1 for succes or 0 for failure.</returns>
-        /// <param name="ctx">Context.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int EVP_MD_CTX_reset(IntPtr ctx);
-
-        /// <summary>
-        /// Frees the message digest context
-        /// </summary>
-        /// <param name="ctx">The message digest context.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static void EVP_MD_CTX_free(IntPtr ctx);
-
-        /// <summary>
-        /// Gets the size of the message digest result
-        /// </summary>
-        /// <returns>The message digest size.</returns>
-        /// <param name="md">The digest implementation.</param>
-        [DllImport(DLLNAME, EntryPoint = "EVP_MD_get_size", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int EVP_MD_size(IntPtr md);
-
-        /// <summary>
-        /// Gets the size of the input blocks
-        /// </summary>
-        /// <returns>The input block size.</returns>
-        /// <param name="md">The digest implementation.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int EVP_MD_block_size(IntPtr md);
-
-        /// <summary>
-        /// Gets the string representation of the SSL library version
-        /// </summary>
-        /// <returns>A const char* with the SSL version.</returns>
-        /// <param name="t">The version information to obtain (use zero).</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static IntPtr OpenSSL_version(int t = 0);
-		
-		/// <summary>
-        /// Gets the string representation of the SSL library version
-        /// </summary>
-        /// <returns>A const long with the SSL version.</returns>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int OpenSSL_version_num();
-    }
-
-    /// <summary>
-    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libssl-3-x64.dll
-    /// </summary>
-    internal static class InteropOpenSSL30_libssl_3_x64_dll
-    {
-        /// <summary>
-        /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
-        /// </summary>
-        private const string DLLNAME = "libssl-3-x64.dll";
-
-        /// <summary>
-        /// Initializes the message digest context with the hashing method
-        /// </summary>
-        /// <returns>1 for succes or 0 for failure.</returns>
-        /// <param name="ctx">The message digest context.</param>
-        /// <param name="type">The digest type.</param>
-        /// <param name="impl">The digest implementation.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int EVP_DigestInit_ex(IntPtr ctx, IntPtr type, IntPtr impl);
-
-        /// <summary>
-        /// Processes a chunk of data, updating the message digest
-        /// </summary>
-        /// <returns>1 for succes or 0 for failure.</returns>
-        /// <param name="ctx">The message digest context.</param>
-        /// <param name="data">The data to update the digest with.</param>
-        /// <param name="cnt">The number of bytes in the buffer.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int EVP_DigestUpdate(IntPtr ctx, byte[] data, uint cnt);
-        
-        /// <summary>
-        /// Processes a chunk of data, updating the message digest
-        /// </summary>
-        /// <returns>1 for succes or 0 for failure.</returns>
-        /// <param name="ctx">The message digest context.</param>
-        /// <param name="data">The data to update the digest with.</param>
-        /// <param name="cnt">The number of bytes in the buffer.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int EVP_DigestUpdate(IntPtr ctx, IntPtr data, uint cnt);
-
-        /// <summary>
-        /// Completes the message digest
-        /// </summary>
-        /// <returns>1 for succes or 0 for failure.</returns>
-        /// <param name="ctx">The context to use.</param>
-        /// <param name="result">A buffer to contain the result.</param>
-        /// <param name="s">The length of the buffer.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int EVP_DigestFinal_ex(IntPtr ctx, byte[] result, ref uint s);
-
-        /// <summary>
-        /// Gets the digest implementation from a anme
-        /// </summary>
-        /// <returns>The digest implementation or null.</returns>
-        /// <param name="name">The name of the digets to find.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static IntPtr EVP_get_digestbyname(string name);
-
-
-        /// <summary>
-        /// Creates the message digest context
-        /// </summary>
-        /// <returns>The message digest context.</returns>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static IntPtr EVP_MD_CTX_new();
-
-        /// <summary>
-        /// Resets the message digest context
-        /// </summary>
-        /// <returns>1 for succes or 0 for failure.</returns>
-        /// <param name="ctx">Context.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int EVP_MD_CTX_reset(IntPtr ctx);
-
-        /// <summary>
-        /// Frees the message digest context
-        /// </summary>
-        /// <param name="ctx">The message digest context.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static void EVP_MD_CTX_free(IntPtr ctx);
-
-        /// <summary>
-        /// Gets the size of the message digest result
-        /// </summary>
-        /// <returns>The message digest size.</returns>
-        /// <param name="md">The digest implementation.</param>
-        [DllImport(DLLNAME, EntryPoint = "EVP_MD_get_size", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int EVP_MD_size(IntPtr md);
-
-        /// <summary>
-        /// Gets the size of the input blocks
-        /// </summary>
-        /// <returns>The input block size.</returns>
-        /// <param name="md">The digest implementation.</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int EVP_MD_block_size(IntPtr md);
-
-        /// <summary>
-        /// Gets the string representation of the SSL library version
-        /// </summary>
-        /// <returns>A const char* with the SSL version.</returns>
-        /// <param name="t">The version information to obtain (use zero).</param>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static IntPtr OpenSSL_version(int t = 0);
-		
-		/// <summary>
-        /// Gets the string representation of the SSL library version
-        /// </summary>
-        /// <returns>A const long with the SSL version.</returns>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int OpenSSL_version_num();
-    }
-
-    /// <summary>
-    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libcrypto-3.dll
-    /// </summary>
-    internal static class InteropOpenSSL30_libcrypto_3_dll
+    internal static class InteropOpenSSL3_libcrypto_3_dll
     {
         /// <summary>
         /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
@@ -2039,19 +1785,12 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);
-		
-		/// <summary>
-        /// Gets the string representation of the SSL library version
-        /// </summary>
-        /// <returns>A const long with the SSL version.</returns>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int OpenSSL_version_num();
     }
 
     /// <summary>
-    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libcrypto-3-x64.dll
+    /// P/Invoke signatures for OpenSSL 3 libraries, using libcrypto-3-x64.dll
     /// </summary>
-    internal static class InteropOpenSSL30_libcrypto_3_x64_dll
+    internal static class InteropOpenSSL3_libcrypto_3_x64_dll
     {
         /// <summary>
         /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
@@ -2152,13 +1891,6 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);
-		
-		/// <summary>
-        /// Gets the string representation of the SSL library version
-        /// </summary>
-        /// <returns>A const long with the SSL version.</returns>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int OpenSSL_version_num();
     }
 
 }

--- a/FasterHashing/InteropOpenSSL.cs
+++ b/FasterHashing/InteropOpenSSL.cs
@@ -1,16 +1,10 @@
-﻿
-
-
-
-
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
 namespace FasterHashing
 {
-
     /// <summary>
     /// P/Invoke signatures for OpenSSL 1.0 libraries, using libssl
     /// </summary>
@@ -121,7 +115,6 @@ namespace FasterHashing
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true, CharSet = CharSet.Ansi)]
         public extern static IntPtr SSLeay_version(int t = 0);
     }
-
 
     /// <summary>
     /// P/Invoke signatures for OpenSSL 1.0 libraries, using libssl.so.1.0
@@ -234,7 +227,6 @@ namespace FasterHashing
         public extern static IntPtr SSLeay_version(int t = 0);
     }
 
-
     /// <summary>
     /// P/Invoke signatures for OpenSSL 1.0 libraries, using libssl.so.1.0.0
     /// </summary>
@@ -345,7 +337,6 @@ namespace FasterHashing
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true, CharSet = CharSet.Ansi)]
         public extern static IntPtr SSLeay_version(int t = 0);
     }
-
 
     /// <summary>
     /// P/Invoke signatures for OpenSSL 1.0 libraries, using libeay32.dll
@@ -460,8 +451,6 @@ namespace FasterHashing
 
 
 
-
-
     /// <summary>
     /// P/Invoke signatures for OpenSSL 1.1 libraries, using libssl
     /// </summary>
@@ -550,6 +539,8 @@ namespace FasterHashing
         /// <param name="md">The digest implementation.</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static int EVP_MD_size(IntPtr md);
+		[DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_get_size(IntPtr md);
 
         /// <summary>
         /// Gets the size of the input blocks
@@ -566,8 +557,14 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);    
-    }
-
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+		}
 
     /// <summary>
     /// P/Invoke signatures for OpenSSL 1.1 libraries, using libssl.so.1.1
@@ -657,6 +654,8 @@ namespace FasterHashing
         /// <param name="md">The digest implementation.</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static int EVP_MD_size(IntPtr md);
+		[DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_get_size(IntPtr md);
 
         /// <summary>
         /// Gets the size of the input blocks
@@ -673,8 +672,14 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);    
-    }
-
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+		}
 
     /// <summary>
     /// P/Invoke signatures for OpenSSL 1.1 libraries, using libssl.so.1.1.0
@@ -764,6 +769,8 @@ namespace FasterHashing
         /// <param name="md">The digest implementation.</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static int EVP_MD_size(IntPtr md);
+		[DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_get_size(IntPtr md);
 
         /// <summary>
         /// Gets the size of the input blocks
@@ -780,8 +787,14 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);    
-    }
-
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+		}
 
     /// <summary>
     /// P/Invoke signatures for OpenSSL 1.1 libraries, using libcrypto.dll
@@ -871,6 +884,8 @@ namespace FasterHashing
         /// <param name="md">The digest implementation.</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static int EVP_MD_size(IntPtr md);
+		[DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_get_size(IntPtr md);
 
         /// <summary>
         /// Gets the size of the input blocks
@@ -887,8 +902,14 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);    
-    }
-
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+		}
 
     /// <summary>
     /// P/Invoke signatures for OpenSSL 1.1 libraries, using libcrypto-1_1.dll
@@ -978,6 +999,8 @@ namespace FasterHashing
         /// <param name="md">The digest implementation.</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static int EVP_MD_size(IntPtr md);
+		[DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_get_size(IntPtr md);
 
         /// <summary>
         /// Gets the size of the input blocks
@@ -994,8 +1017,14 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);    
-    }
-
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+		}
 
     /// <summary>
     /// P/Invoke signatures for OpenSSL 1.1 libraries, using libcrypto-1_1-x64.dll
@@ -1085,6 +1114,8 @@ namespace FasterHashing
         /// <param name="md">The digest implementation.</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static int EVP_MD_size(IntPtr md);
+		[DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_get_size(IntPtr md);
 
         /// <summary>
         /// Gets the size of the input blocks
@@ -1101,8 +1132,14 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);    
-    }
-
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+		}
 
     /// <summary>
     /// P/Invoke signatures for OpenSSL 1.1 libraries, using libcrypto-x64.dll
@@ -1192,6 +1229,8 @@ namespace FasterHashing
         /// <param name="md">The digest implementation.</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static int EVP_MD_size(IntPtr md);
+		[DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_get_size(IntPtr md);
 
         /// <summary>
         /// Gets the size of the input blocks
@@ -1208,7 +1247,918 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);    
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+		}
+
+
+    /// <summary>
+    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libssl
+    /// </summary>
+    internal static class InteropOpenSSL30_libssl
+    {
+        /// <summary>
+        /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
+        /// </summary>
+        private const string DLLNAME = "libssl";
+
+        /// <summary>
+        /// Initializes the message digest context with the hashing method
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="type">The digest type.</param>
+        /// <param name="impl">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestInit_ex(IntPtr ctx, IntPtr type, IntPtr impl);
+
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, byte[] data, uint cnt);
+        
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, IntPtr data, uint cnt);
+
+        /// <summary>
+        /// Completes the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The context to use.</param>
+        /// <param name="result">A buffer to contain the result.</param>
+        /// <param name="s">The length of the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestFinal_ex(IntPtr ctx, byte[] result, ref uint s);
+
+        /// <summary>
+        /// Gets the digest implementation from a anme
+        /// </summary>
+        /// <returns>The digest implementation or null.</returns>
+        /// <param name="name">The name of the digets to find.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_get_digestbyname(string name);
+
+
+        /// <summary>
+        /// Creates the message digest context
+        /// </summary>
+        /// <returns>The message digest context.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_MD_CTX_new();
+
+        /// <summary>
+        /// Resets the message digest context
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">Context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_CTX_reset(IntPtr ctx);
+
+        /// <summary>
+        /// Frees the message digest context
+        /// </summary>
+        /// <param name="ctx">The message digest context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static void EVP_MD_CTX_free(IntPtr ctx);
+
+        /// <summary>
+        /// Gets the size of the message digest result
+        /// </summary>
+        /// <returns>The message digest size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, EntryPoint = "EVP_MD_get_size", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the size of the input blocks
+        /// </summary>
+        /// <returns>The input block size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_block_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const char* with the SSL version.</returns>
+        /// <param name="t">The version information to obtain (use zero).</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr OpenSSL_version(int t = 0);
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
     }
 
+    /// <summary>
+    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libssl.so.3
+    /// </summary>
+    internal static class InteropOpenSSL30_libssl_so_3
+    {
+        /// <summary>
+        /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
+        /// </summary>
+        private const string DLLNAME = "libssl.so.3";
+
+        /// <summary>
+        /// Initializes the message digest context with the hashing method
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="type">The digest type.</param>
+        /// <param name="impl">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestInit_ex(IntPtr ctx, IntPtr type, IntPtr impl);
+
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, byte[] data, uint cnt);
+        
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, IntPtr data, uint cnt);
+
+        /// <summary>
+        /// Completes the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The context to use.</param>
+        /// <param name="result">A buffer to contain the result.</param>
+        /// <param name="s">The length of the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestFinal_ex(IntPtr ctx, byte[] result, ref uint s);
+
+        /// <summary>
+        /// Gets the digest implementation from a anme
+        /// </summary>
+        /// <returns>The digest implementation or null.</returns>
+        /// <param name="name">The name of the digets to find.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_get_digestbyname(string name);
+
+
+        /// <summary>
+        /// Creates the message digest context
+        /// </summary>
+        /// <returns>The message digest context.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_MD_CTX_new();
+
+        /// <summary>
+        /// Resets the message digest context
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">Context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_CTX_reset(IntPtr ctx);
+
+        /// <summary>
+        /// Frees the message digest context
+        /// </summary>
+        /// <param name="ctx">The message digest context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static void EVP_MD_CTX_free(IntPtr ctx);
+
+        /// <summary>
+        /// Gets the size of the message digest result
+        /// </summary>
+        /// <returns>The message digest size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, EntryPoint = "EVP_MD_get_size", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the size of the input blocks
+        /// </summary>
+        /// <returns>The input block size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_block_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const char* with the SSL version.</returns>
+        /// <param name="t">The version information to obtain (use zero).</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr OpenSSL_version(int t = 0);
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+    }
+
+    /// <summary>
+    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libcrypto.so
+    /// </summary>
+    internal static class InteropOpenSSL30_libcrypto_so
+    {
+        /// <summary>
+        /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
+        /// </summary>
+        private const string DLLNAME = "libcrypto.so";
+
+        /// <summary>
+        /// Initializes the message digest context with the hashing method
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="type">The digest type.</param>
+        /// <param name="impl">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestInit_ex(IntPtr ctx, IntPtr type, IntPtr impl);
+
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, byte[] data, uint cnt);
+        
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, IntPtr data, uint cnt);
+
+        /// <summary>
+        /// Completes the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The context to use.</param>
+        /// <param name="result">A buffer to contain the result.</param>
+        /// <param name="s">The length of the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestFinal_ex(IntPtr ctx, byte[] result, ref uint s);
+
+        /// <summary>
+        /// Gets the digest implementation from a anme
+        /// </summary>
+        /// <returns>The digest implementation or null.</returns>
+        /// <param name="name">The name of the digets to find.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_get_digestbyname(string name);
+
+
+        /// <summary>
+        /// Creates the message digest context
+        /// </summary>
+        /// <returns>The message digest context.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_MD_CTX_new();
+
+        /// <summary>
+        /// Resets the message digest context
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">Context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_CTX_reset(IntPtr ctx);
+
+        /// <summary>
+        /// Frees the message digest context
+        /// </summary>
+        /// <param name="ctx">The message digest context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static void EVP_MD_CTX_free(IntPtr ctx);
+
+        /// <summary>
+        /// Gets the size of the message digest result
+        /// </summary>
+        /// <returns>The message digest size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, EntryPoint = "EVP_MD_get_size", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the size of the input blocks
+        /// </summary>
+        /// <returns>The input block size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_block_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const char* with the SSL version.</returns>
+        /// <param name="t">The version information to obtain (use zero).</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr OpenSSL_version(int t = 0);
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+    }
+
+    /// <summary>
+    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libcrypto.so.3
+    /// </summary>
+    internal static class InteropOpenSSL30_libcrypto_so_3
+    {
+        /// <summary>
+        /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
+        /// </summary>
+        private const string DLLNAME = "libcrypto.so.3";
+
+        /// <summary>
+        /// Initializes the message digest context with the hashing method
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="type">The digest type.</param>
+        /// <param name="impl">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestInit_ex(IntPtr ctx, IntPtr type, IntPtr impl);
+
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, byte[] data, uint cnt);
+        
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, IntPtr data, uint cnt);
+
+        /// <summary>
+        /// Completes the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The context to use.</param>
+        /// <param name="result">A buffer to contain the result.</param>
+        /// <param name="s">The length of the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestFinal_ex(IntPtr ctx, byte[] result, ref uint s);
+
+        /// <summary>
+        /// Gets the digest implementation from a anme
+        /// </summary>
+        /// <returns>The digest implementation or null.</returns>
+        /// <param name="name">The name of the digets to find.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_get_digestbyname(string name);
+
+
+        /// <summary>
+        /// Creates the message digest context
+        /// </summary>
+        /// <returns>The message digest context.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_MD_CTX_new();
+
+        /// <summary>
+        /// Resets the message digest context
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">Context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_CTX_reset(IntPtr ctx);
+
+        /// <summary>
+        /// Frees the message digest context
+        /// </summary>
+        /// <param name="ctx">The message digest context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static void EVP_MD_CTX_free(IntPtr ctx);
+
+        /// <summary>
+        /// Gets the size of the message digest result
+        /// </summary>
+        /// <returns>The message digest size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, EntryPoint = "EVP_MD_get_size", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the size of the input blocks
+        /// </summary>
+        /// <returns>The input block size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_block_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const char* with the SSL version.</returns>
+        /// <param name="t">The version information to obtain (use zero).</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr OpenSSL_version(int t = 0);
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+    }
+
+    /// <summary>
+    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libssl-3.dll
+    /// </summary>
+    internal static class InteropOpenSSL30_libssl_3_dll
+    {
+        /// <summary>
+        /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
+        /// </summary>
+        private const string DLLNAME = "libssl-3.dll";
+
+        /// <summary>
+        /// Initializes the message digest context with the hashing method
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="type">The digest type.</param>
+        /// <param name="impl">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestInit_ex(IntPtr ctx, IntPtr type, IntPtr impl);
+
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, byte[] data, uint cnt);
+        
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, IntPtr data, uint cnt);
+
+        /// <summary>
+        /// Completes the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The context to use.</param>
+        /// <param name="result">A buffer to contain the result.</param>
+        /// <param name="s">The length of the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestFinal_ex(IntPtr ctx, byte[] result, ref uint s);
+
+        /// <summary>
+        /// Gets the digest implementation from a anme
+        /// </summary>
+        /// <returns>The digest implementation or null.</returns>
+        /// <param name="name">The name of the digets to find.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_get_digestbyname(string name);
+
+
+        /// <summary>
+        /// Creates the message digest context
+        /// </summary>
+        /// <returns>The message digest context.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_MD_CTX_new();
+
+        /// <summary>
+        /// Resets the message digest context
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">Context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_CTX_reset(IntPtr ctx);
+
+        /// <summary>
+        /// Frees the message digest context
+        /// </summary>
+        /// <param name="ctx">The message digest context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static void EVP_MD_CTX_free(IntPtr ctx);
+
+        /// <summary>
+        /// Gets the size of the message digest result
+        /// </summary>
+        /// <returns>The message digest size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, EntryPoint = "EVP_MD_get_size", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the size of the input blocks
+        /// </summary>
+        /// <returns>The input block size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_block_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const char* with the SSL version.</returns>
+        /// <param name="t">The version information to obtain (use zero).</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr OpenSSL_version(int t = 0);
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+    }
+
+    /// <summary>
+    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libssl-3-x64.dll
+    /// </summary>
+    internal static class InteropOpenSSL30_libssl_3_x64_dll
+    {
+        /// <summary>
+        /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
+        /// </summary>
+        private const string DLLNAME = "libssl-3-x64.dll";
+
+        /// <summary>
+        /// Initializes the message digest context with the hashing method
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="type">The digest type.</param>
+        /// <param name="impl">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestInit_ex(IntPtr ctx, IntPtr type, IntPtr impl);
+
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, byte[] data, uint cnt);
+        
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, IntPtr data, uint cnt);
+
+        /// <summary>
+        /// Completes the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The context to use.</param>
+        /// <param name="result">A buffer to contain the result.</param>
+        /// <param name="s">The length of the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestFinal_ex(IntPtr ctx, byte[] result, ref uint s);
+
+        /// <summary>
+        /// Gets the digest implementation from a anme
+        /// </summary>
+        /// <returns>The digest implementation or null.</returns>
+        /// <param name="name">The name of the digets to find.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_get_digestbyname(string name);
+
+
+        /// <summary>
+        /// Creates the message digest context
+        /// </summary>
+        /// <returns>The message digest context.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_MD_CTX_new();
+
+        /// <summary>
+        /// Resets the message digest context
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">Context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_CTX_reset(IntPtr ctx);
+
+        /// <summary>
+        /// Frees the message digest context
+        /// </summary>
+        /// <param name="ctx">The message digest context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static void EVP_MD_CTX_free(IntPtr ctx);
+
+        /// <summary>
+        /// Gets the size of the message digest result
+        /// </summary>
+        /// <returns>The message digest size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, EntryPoint = "EVP_MD_get_size", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the size of the input blocks
+        /// </summary>
+        /// <returns>The input block size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_block_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const char* with the SSL version.</returns>
+        /// <param name="t">The version information to obtain (use zero).</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr OpenSSL_version(int t = 0);
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+    }
+
+    /// <summary>
+    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libcrypto-3.dll
+    /// </summary>
+    internal static class InteropOpenSSL30_libcrypto_3_dll
+    {
+        /// <summary>
+        /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
+        /// </summary>
+        private const string DLLNAME = "libcrypto-3.dll";
+
+        /// <summary>
+        /// Initializes the message digest context with the hashing method
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="type">The digest type.</param>
+        /// <param name="impl">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestInit_ex(IntPtr ctx, IntPtr type, IntPtr impl);
+
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, byte[] data, uint cnt);
+        
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, IntPtr data, uint cnt);
+
+        /// <summary>
+        /// Completes the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The context to use.</param>
+        /// <param name="result">A buffer to contain the result.</param>
+        /// <param name="s">The length of the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestFinal_ex(IntPtr ctx, byte[] result, ref uint s);
+
+        /// <summary>
+        /// Gets the digest implementation from a anme
+        /// </summary>
+        /// <returns>The digest implementation or null.</returns>
+        /// <param name="name">The name of the digets to find.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_get_digestbyname(string name);
+
+
+        /// <summary>
+        /// Creates the message digest context
+        /// </summary>
+        /// <returns>The message digest context.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_MD_CTX_new();
+
+        /// <summary>
+        /// Resets the message digest context
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">Context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_CTX_reset(IntPtr ctx);
+
+        /// <summary>
+        /// Frees the message digest context
+        /// </summary>
+        /// <param name="ctx">The message digest context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static void EVP_MD_CTX_free(IntPtr ctx);
+
+        /// <summary>
+        /// Gets the size of the message digest result
+        /// </summary>
+        /// <returns>The message digest size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, EntryPoint = "EVP_MD_get_size", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the size of the input blocks
+        /// </summary>
+        /// <returns>The input block size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_block_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const char* with the SSL version.</returns>
+        /// <param name="t">The version information to obtain (use zero).</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr OpenSSL_version(int t = 0);
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+    }
+
+    /// <summary>
+    /// P/Invoke signatures for OpenSSL 3.0 libraries, using libcrypto-3-x64.dll
+    /// </summary>
+    internal static class InteropOpenSSL30_libcrypto_3_x64_dll
+    {
+        /// <summary>
+        /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
+        /// </summary>
+        private const string DLLNAME = "libcrypto-3-x64.dll";
+
+        /// <summary>
+        /// Initializes the message digest context with the hashing method
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="type">The digest type.</param>
+        /// <param name="impl">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestInit_ex(IntPtr ctx, IntPtr type, IntPtr impl);
+
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, byte[] data, uint cnt);
+        
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, IntPtr data, uint cnt);
+
+        /// <summary>
+        /// Completes the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The context to use.</param>
+        /// <param name="result">A buffer to contain the result.</param>
+        /// <param name="s">The length of the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestFinal_ex(IntPtr ctx, byte[] result, ref uint s);
+
+        /// <summary>
+        /// Gets the digest implementation from a anme
+        /// </summary>
+        /// <returns>The digest implementation or null.</returns>
+        /// <param name="name">The name of the digets to find.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_get_digestbyname(string name);
+
+
+        /// <summary>
+        /// Creates the message digest context
+        /// </summary>
+        /// <returns>The message digest context.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_MD_CTX_new();
+
+        /// <summary>
+        /// Resets the message digest context
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">Context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_CTX_reset(IntPtr ctx);
+
+        /// <summary>
+        /// Frees the message digest context
+        /// </summary>
+        /// <param name="ctx">The message digest context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static void EVP_MD_CTX_free(IntPtr ctx);
+
+        /// <summary>
+        /// Gets the size of the message digest result
+        /// </summary>
+        /// <returns>The message digest size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, EntryPoint = "EVP_MD_get_size", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the size of the input blocks
+        /// </summary>
+        /// <returns>The input block size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_block_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const char* with the SSL version.</returns>
+        /// <param name="t">The version information to obtain (use zero).</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr OpenSSL_version(int t = 0);
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+    }
 
 }

--- a/FasterHashing/InteropOpenSSL.tt
+++ b/FasterHashing/InteropOpenSSL.tt
@@ -14,7 +14,7 @@ namespace FasterHashing
   var libnames_10 = new [] { "libssl", "libssl.so.1.0", "libssl.so.1.0.0", "libeay32.dll" };
   var libnames_11 = new [] { "libssl", "libssl.so.1.1", "libssl.so.1.1.0", "libcrypto.dll", "libcrypto-1_1.dll", "libcrypto-1_1-x64.dll", "libcrypto-x64.dll" };
   // var libnames_11 = new [] { "libssl", "libssl.so.1.1", "libssl.so.1.1.0", "libcrypto-1_1.dll", "libcrypto-1_1-x64.dll"};
-  var libnames_30 = new [] {  "libssl", "libssl.so.3","libcrypto.so", "libcrypto.so.3","libssl-3.dll", "libssl-3-x64.dll","libcrypto-3.dll", "libcrypto-3-x64.dll" };
+  var libnames_3 = new [] {  "libssl", "libssl.so.3","libcrypto.so", "libcrypto.so.3", "libcrypto-3.dll", "libcrypto-3-x64.dll" };
 
   foreach(var _soname in libnames_10) {
     var soname = _soname.Replace(".", "_").Replace("-", "_");
@@ -255,13 +255,13 @@ namespace FasterHashing
 <# } #>
 
 <#
-  foreach(var _soname in libnames_30) {
+  foreach(var _soname in libnames_3) {
     var soname = _soname.Replace(".", "_").Replace("-", "_");
 #>
     /// <summary>
-    /// P/Invoke signatures for OpenSSL 3.0 libraries, using <#= _soname #>
+    /// P/Invoke signatures for OpenSSL 3 libraries, using <#= _soname #>
     /// </summary>
-    internal static class InteropOpenSSL30_<#= soname #>
+    internal static class InteropOpenSSL3_<#= soname #>
     {
         /// <summary>
         /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
@@ -362,13 +362,6 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);
-		
-		/// <summary>
-        /// Gets the string representation of the SSL library version
-        /// </summary>
-        /// <returns>A const long with the SSL version.</returns>
-        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
-        public extern static int OpenSSL_version_num();
     }
 
 <# } #>

--- a/FasterHashing/InteropOpenSSL.tt
+++ b/FasterHashing/InteropOpenSSL.tt
@@ -13,6 +13,8 @@ namespace FasterHashing
 <# 
   var libnames_10 = new [] { "libssl", "libssl.so.1.0", "libssl.so.1.0.0", "libeay32.dll" };
   var libnames_11 = new [] { "libssl", "libssl.so.1.1", "libssl.so.1.1.0", "libcrypto.dll", "libcrypto-1_1.dll", "libcrypto-1_1-x64.dll", "libcrypto-x64.dll" };
+  // var libnames_11 = new [] { "libssl", "libssl.so.1.1", "libssl.so.1.1.0", "libcrypto-1_1.dll", "libcrypto-1_1-x64.dll"};
+  var libnames_30 = new [] {  "libssl", "libssl.so.3","libcrypto.so", "libcrypto.so.3","libssl-3.dll", "libssl-3-x64.dll","libcrypto-3.dll", "libcrypto-3-x64.dll" };
 
   foreach(var _soname in libnames_10) {
     var soname = _soname.Replace(".", "_").Replace("-", "_");
@@ -223,6 +225,8 @@ namespace FasterHashing
         /// <param name="md">The digest implementation.</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static int EVP_MD_size(IntPtr md);
+		[DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_get_size(IntPtr md);
 
         /// <summary>
         /// Gets the size of the input blocks
@@ -239,6 +243,132 @@ namespace FasterHashing
         /// <param name="t">The version information to obtain (use zero).</param>
         [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
         public extern static IntPtr OpenSSL_version(int t = 0);    
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
+		}
+
+<# } #>
+
+<#
+  foreach(var _soname in libnames_30) {
+    var soname = _soname.Replace(".", "_").Replace("-", "_");
+#>
+    /// <summary>
+    /// P/Invoke signatures for OpenSSL 3.0 libraries, using <#= _soname #>
+    /// </summary>
+    internal static class InteropOpenSSL30_<#= soname #>
+    {
+        /// <summary>
+        /// The library implementing OpenSSL (automatically uses .dll, .so, or .dylib)
+        /// </summary>
+        private const string DLLNAME = "<#= _soname #>";
+
+        /// <summary>
+        /// Initializes the message digest context with the hashing method
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="type">The digest type.</param>
+        /// <param name="impl">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestInit_ex(IntPtr ctx, IntPtr type, IntPtr impl);
+
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, byte[] data, uint cnt);
+        
+        /// <summary>
+        /// Processes a chunk of data, updating the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The message digest context.</param>
+        /// <param name="data">The data to update the digest with.</param>
+        /// <param name="cnt">The number of bytes in the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestUpdate(IntPtr ctx, IntPtr data, uint cnt);
+
+        /// <summary>
+        /// Completes the message digest
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">The context to use.</param>
+        /// <param name="result">A buffer to contain the result.</param>
+        /// <param name="s">The length of the buffer.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_DigestFinal_ex(IntPtr ctx, byte[] result, ref uint s);
+
+        /// <summary>
+        /// Gets the digest implementation from a anme
+        /// </summary>
+        /// <returns>The digest implementation or null.</returns>
+        /// <param name="name">The name of the digets to find.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_get_digestbyname(string name);
+
+
+        /// <summary>
+        /// Creates the message digest context
+        /// </summary>
+        /// <returns>The message digest context.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr EVP_MD_CTX_new();
+
+        /// <summary>
+        /// Resets the message digest context
+        /// </summary>
+        /// <returns>1 for succes or 0 for failure.</returns>
+        /// <param name="ctx">Context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_CTX_reset(IntPtr ctx);
+
+        /// <summary>
+        /// Frees the message digest context
+        /// </summary>
+        /// <param name="ctx">The message digest context.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static void EVP_MD_CTX_free(IntPtr ctx);
+
+        /// <summary>
+        /// Gets the size of the message digest result
+        /// </summary>
+        /// <returns>The message digest size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, EntryPoint = "EVP_MD_get_size", CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the size of the input blocks
+        /// </summary>
+        /// <returns>The input block size.</returns>
+        /// <param name="md">The digest implementation.</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int EVP_MD_block_size(IntPtr md);
+
+        /// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const char* with the SSL version.</returns>
+        /// <param name="t">The version information to obtain (use zero).</param>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static IntPtr OpenSSL_version(int t = 0);
+		
+		/// <summary>
+        /// Gets the string representation of the SSL library version
+        /// </summary>
+        /// <returns>A const long with the SSL version.</returns>
+        [DllImport(DLLNAME, CallingConvention = CallingConvention.Cdecl, SetLastError = true)]
+        public extern static int OpenSSL_version_num();
     }
 
 <# } #>

--- a/FasterHashing/OpenSSLHelper.cs
+++ b/FasterHashing/OpenSSLHelper.cs
@@ -46,7 +46,7 @@ namespace FasterHashing
                 case LibraryName.libeay32_dll:
                     return OpenSSL10_libeay32_dll_HashAlgorithm.Create(algorithm);
 
-                //case LibraryName.libssl:
+                //case LibraryName.libssl3:
                 default:
                     return OpenSSL10_libssl_HashAlgorithm.Create(algorithm);
             }
@@ -62,7 +62,7 @@ namespace FasterHashing
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL1.0 from libssl.so.1.0.0: {ex}");
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL1.0 from libssl3.so.1.0.0: {ex}");
             }
 
             try
@@ -73,7 +73,7 @@ namespace FasterHashing
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL1.0 from libssl.so.1.0: {ex}");
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL1.0 from libssl3.so.1.0: {ex}");
             }
 
             try
@@ -104,7 +104,7 @@ namespace FasterHashing
                 case LibraryName.libeay32_dll:
                     return Marshal.PtrToStringAuto(InteropOpenSSL10_libeay32_dll.SSLeay_version());
 
-                //case LibraryName.libssl:
+                //case LibraryName.libssl3:
                 default:
                     return Marshal.PtrToStringAuto(InteropOpenSSL10_libssl.SSLeay_version());
             }
@@ -162,7 +162,7 @@ namespace FasterHashing
                 case LibraryName.libcrypto_1_1_x64_dll:
                     return OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithm.Create(algorithm);
 
-                //case LibraryName.libssl:
+                //case LibraryName.libssl3:
                 default:
                     return OpenSSL11_libssl_HashAlgorithm.Create(algorithm);
             }
@@ -176,21 +176,21 @@ namespace FasterHashing
             switch (library)
             {
                 case LibraryName.libssl_so_1_1:
-                    return Marshal.PtrToStringAuto(InteropOpenSSL11_libssl_so_1_1.OpenSSL_version());
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL11_libssl_so_1_1.OpenSSL_version());
                 case LibraryName.libssl_so_1_1_0:
-                    return Marshal.PtrToStringAuto(InteropOpenSSL11_libssl_so_1_1_0.OpenSSL_version());
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL11_libssl_so_1_1_0.OpenSSL_version());
                 case LibraryName.libcrypto_dll:
-                    return Marshal.PtrToStringAuto(InteropOpenSSL11_libcrypto_dll.OpenSSL_version());
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL11_libcrypto_dll.OpenSSL_version());
                 case LibraryName.libcrypto_x64_dll:
-                    return Marshal.PtrToStringAuto(InteropOpenSSL11_libcrypto_x64_dll.OpenSSL_version());
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL11_libcrypto_x64_dll.OpenSSL_version());
                 case LibraryName.libcrypto_1_1_dll:
-                    return Marshal.PtrToStringAuto(InteropOpenSSL11_libcrypto_1_1_dll.OpenSSL_version());
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL11_libcrypto_1_1_dll.OpenSSL_version());
                 case LibraryName.libcrypto_1_1_x64_dll:
-                    return Marshal.PtrToStringAuto(InteropOpenSSL11_libcrypto_1_1_x64_dll.OpenSSL_version());
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL11_libcrypto_1_1_x64_dll.OpenSSL_version());
 
-                //case LibraryName.libssl:
+                //case LibraryName.libssl3:
                 default:
-                    return Marshal.PtrToStringAuto(InteropOpenSSL11_libssl.OpenSSL_version());
+                   return Marshal.PtrToStringAnsi(InteropOpenSSL11_libssl.OpenSSL_version());
             }
         }
 
@@ -204,7 +204,7 @@ namespace FasterHashing
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL1.1 from libssl.so.1.1.0: {ex}");
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL1.1 from libssl3.so.1.1.0: {ex}");
             }
 
             try
@@ -215,7 +215,7 @@ namespace FasterHashing
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL1.1 from libssl.so.1.1: {ex}");
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL1.1 from libssl3.so.1.1: {ex}");
             }
 
             try
@@ -237,7 +237,7 @@ namespace FasterHashing
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL1.1 from libcrypto.dll: {ex}");
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL1.1 from libcrypto_x64.dll: {ex}");
             }
 
             try
@@ -248,7 +248,7 @@ namespace FasterHashing
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL1.1 from libcrypto.dll: {ex}");
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL1.1 from libcrypto-1-1_dll: {ex}");
             }
 
             try
@@ -259,9 +259,183 @@ namespace FasterHashing
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL1.1 from libcrypto.dll: {ex}");
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL1.1 from libcrypto-1-1-x64_dll.dll: {ex}");
             }
 
+
+            return LibraryName.libssl;
+        }
+
+    }
+
+    public static class OpenSSL30HashAlgorithm
+    {
+        public enum LibraryName
+        {
+            //  "libssl", "libssl.so.3", "libcrypto.so", "libcrypto.so.3","libssl-3.dll", "libssl-3-x64.dll","libcrypto-3.dll", "libcrypto-3-x64.dll" 
+            unknown,
+            libssl,
+            libssl_so_3,
+            libssl_3_dll,
+            libssl_3_x64_dll,
+            libcrypto_so,
+            libcrypto_so_3,
+            libcrypto_dll,
+            libcrypto_x64_dll,
+            libcrypto_3_dll,
+            libcrypto_3_x64_dll
+        }
+
+        private static LibraryName _libname = LibraryName.unknown;
+
+        public static LibraryName DefaultLibrary
+        {
+            get
+            {
+                if (_libname == LibraryName.unknown)
+                    _libname = GetDefaultLibrary();
+                return _libname;
+            }
+            set
+            {
+                if (value == LibraryName.unknown)
+                    throw new ArgumentException("Cannot set library to unknown");
+            }
+        }
+
+        public static HashAlgorithm Create(string algorithm, LibraryName library = LibraryName.unknown)
+        {
+            if (library == LibraryName.unknown)
+                library = DefaultLibrary;
+
+            switch (library)
+            {
+                case LibraryName.libssl_so_3:
+                    return OpenSSL30_libssl_so_3_HashAlgorithm.Create(algorithm);
+                case LibraryName.libcrypto_so:
+                    return OpenSSL30_libcrypto_so_HashAlgorithm.Create(algorithm);
+                case LibraryName.libcrypto_so_3:
+                    return OpenSSL30_libcrypto_so_3_HashAlgorithm.Create(algorithm);
+                case LibraryName.libcrypto_3_dll:
+                    return OpenSSL30_libcrypto_3_dll_HashAlgorithm.Create(algorithm);
+                case LibraryName.libcrypto_3_x64_dll:
+                    return OpenSSL30_libcrypto_3_x64_dll_HashAlgorithm.Create(algorithm);
+                case LibraryName.libssl_3_dll:
+                    return OpenSSL30_libssl_3_dll_HashAlgorithm.Create(algorithm);
+                case LibraryName.libssl_3_x64_dll:
+                    return OpenSSL30_libssl_3_x64_dll_HashAlgorithm.Create(algorithm);
+                //case LibraryName.libssl3:
+                default:
+                    return OpenSSL30_libcrypto_so_HashAlgorithm.Create(algorithm);
+            }
+        }
+
+        public static string OpenSSL_version(LibraryName library = LibraryName.unknown)
+        {
+            if (library == LibraryName.unknown)
+                library = DefaultLibrary;
+
+            switch (library)
+            {
+                case LibraryName.libssl_so_3:
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libssl_so_3.OpenSSL_version());
+                case LibraryName.libcrypto_so:
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libcrypto_so.OpenSSL_version());
+                case LibraryName.libcrypto_so_3:
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libcrypto_so_3.OpenSSL_version());
+                case LibraryName.libcrypto_3_dll:
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libcrypto_3_dll.OpenSSL_version());
+                case LibraryName.libcrypto_3_x64_dll:
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libcrypto_3_x64_dll.OpenSSL_version());
+                case LibraryName.libssl_3_dll:
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libssl_3_dll.OpenSSL_version());
+                case LibraryName.libssl_3_x64_dll:
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libssl_3_x64_dll.OpenSSL_version());
+
+                //case LibraryName.libssl3:
+                default:
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libssl.OpenSSL_version());
+            }
+        }
+
+        public static LibraryName GetDefaultLibrary()
+        {
+            try
+            {
+                var ptr = InteropOpenSSL30_libssl_so_3.OpenSSL_version();
+                if (ptr != IntPtr.Zero)
+                    return LibraryName.libssl_so_3;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3 from libssl.so.3: {ex}");
+            }
+
+            try
+            {
+                var ptr = InteropOpenSSL30_libcrypto_so.OpenSSL_version();
+                if (ptr != IntPtr.Zero)
+                    return LibraryName.libcrypto_so;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3 from libcrypto.so: {ex}");
+            }
+
+            try
+            {
+                var ptr = InteropOpenSSL30_libcrypto_so_3.OpenSSL_version();
+                if (ptr != IntPtr.Zero)
+                    return LibraryName.libcrypto_so_3;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3 from libcrypto.so.3: {ex}");
+            }
+
+            try
+            {
+                var ptr = InteropOpenSSL30_libcrypto_3_dll.OpenSSL_version();
+                if (ptr != IntPtr.Zero)
+                    return LibraryName.libcrypto_3_dll;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3 from libcrypto-3.dll: {ex}");
+            }
+
+            try
+            {
+                var ptr = InteropOpenSSL30_libcrypto_3_x64_dll.OpenSSL_version();
+                if (ptr != IntPtr.Zero)
+                    return LibraryName.libcrypto_3_x64_dll;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3 from libcrypto-3-x64.dll: {ex}");
+            }
+
+            try
+            {
+                var ptr = InteropOpenSSL30_libssl_3_dll.OpenSSL_version();
+                if (ptr != IntPtr.Zero)
+                    return LibraryName.libssl_3_dll;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3 from libssl-3.dll: {ex}");
+            }
+
+            try
+            {
+                var ptr = InteropOpenSSL30_libssl_3_x64_dll.OpenSSL_version();
+                if (ptr != IntPtr.Zero)
+                    return LibraryName.libssl_3_x64_dll;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3 from libssl-3-x64.dll: {ex}");
+            }
 
             return LibraryName.libssl;
         }

--- a/FasterHashing/OpenSSLHelper.cs
+++ b/FasterHashing/OpenSSLHelper.cs
@@ -162,7 +162,6 @@ namespace FasterHashing
                 case LibraryName.libcrypto_1_1_x64_dll:
                     return OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithm.Create(algorithm);
 
-                //case LibraryName.libssl3:
                 default:
                     return OpenSSL11_libssl_HashAlgorithm.Create(algorithm);
             }
@@ -188,7 +187,6 @@ namespace FasterHashing
                 case LibraryName.libcrypto_1_1_x64_dll:
                     return Marshal.PtrToStringAnsi(InteropOpenSSL11_libcrypto_1_1_x64_dll.OpenSSL_version());
 
-                //case LibraryName.libssl3:
                 default:
                    return Marshal.PtrToStringAnsi(InteropOpenSSL11_libssl.OpenSSL_version());
             }
@@ -268,16 +266,13 @@ namespace FasterHashing
 
     }
 
-    public static class OpenSSL30HashAlgorithm
+    public static class OpenSSL3HashAlgorithm
     {
         public enum LibraryName
         {
-            //  "libssl", "libssl.so.3", "libcrypto.so", "libcrypto.so.3","libssl-3.dll", "libssl-3-x64.dll","libcrypto-3.dll", "libcrypto-3-x64.dll" 
             unknown,
             libssl,
             libssl_so_3,
-            libssl_3_dll,
-            libssl_3_x64_dll,
             libcrypto_so,
             libcrypto_so_3,
             libcrypto_dll,
@@ -310,23 +305,19 @@ namespace FasterHashing
 
             switch (library)
             {
-                case LibraryName.libssl_so_3:
-                    return OpenSSL30_libssl_so_3_HashAlgorithm.Create(algorithm);
                 case LibraryName.libcrypto_so:
-                    return OpenSSL30_libcrypto_so_HashAlgorithm.Create(algorithm);
+                    return OpenSSL3_libcrypto_so_HashAlgorithm.Create(algorithm);
                 case LibraryName.libcrypto_so_3:
-                    return OpenSSL30_libcrypto_so_3_HashAlgorithm.Create(algorithm);
+                    return OpenSSL3_libcrypto_so_3_HashAlgorithm.Create(algorithm);
                 case LibraryName.libcrypto_3_dll:
-                    return OpenSSL30_libcrypto_3_dll_HashAlgorithm.Create(algorithm);
+                    return OpenSSL3_libcrypto_3_dll_HashAlgorithm.Create(algorithm);
                 case LibraryName.libcrypto_3_x64_dll:
-                    return OpenSSL30_libcrypto_3_x64_dll_HashAlgorithm.Create(algorithm);
-                case LibraryName.libssl_3_dll:
-                    return OpenSSL30_libssl_3_dll_HashAlgorithm.Create(algorithm);
-                case LibraryName.libssl_3_x64_dll:
-                    return OpenSSL30_libssl_3_x64_dll_HashAlgorithm.Create(algorithm);
-                //case LibraryName.libssl3:
+                    return OpenSSL3_libcrypto_3_x64_dll_HashAlgorithm.Create(algorithm);
+                case LibraryName.libssl:
+                    return OpenSSL3_libssl_HashAlgorithm.Create(algorithm);
+
                 default:
-                    return OpenSSL30_libcrypto_so_HashAlgorithm.Create(algorithm);
+                    return OpenSSL3_libcrypto_so_HashAlgorithm.Create(algorithm);
             }
         }
 
@@ -338,23 +329,18 @@ namespace FasterHashing
             switch (library)
             {
                 case LibraryName.libssl_so_3:
-                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libssl_so_3.OpenSSL_version());
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL3_libssl_so_3.OpenSSL_version());
                 case LibraryName.libcrypto_so:
-                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libcrypto_so.OpenSSL_version());
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL3_libcrypto_so.OpenSSL_version());
                 case LibraryName.libcrypto_so_3:
-                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libcrypto_so_3.OpenSSL_version());
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL3_libcrypto_so_3.OpenSSL_version());
                 case LibraryName.libcrypto_3_dll:
-                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libcrypto_3_dll.OpenSSL_version());
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL3_libcrypto_3_dll.OpenSSL_version());
                 case LibraryName.libcrypto_3_x64_dll:
-                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libcrypto_3_x64_dll.OpenSSL_version());
-                case LibraryName.libssl_3_dll:
-                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libssl_3_dll.OpenSSL_version());
-                case LibraryName.libssl_3_x64_dll:
-                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libssl_3_x64_dll.OpenSSL_version());
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL3_libcrypto_3_x64_dll.OpenSSL_version());
 
-                //case LibraryName.libssl3:
                 default:
-                    return Marshal.PtrToStringAnsi(InteropOpenSSL30_libssl.OpenSSL_version());
+                    return Marshal.PtrToStringAnsi(InteropOpenSSL3_libssl.OpenSSL_version());
             }
         }
 
@@ -362,18 +348,7 @@ namespace FasterHashing
         {
             try
             {
-                var ptr = InteropOpenSSL30_libssl_so_3.OpenSSL_version();
-                if (ptr != IntPtr.Zero)
-                    return LibraryName.libssl_so_3;
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3 from libssl.so.3: {ex}");
-            }
-
-            try
-            {
-                var ptr = InteropOpenSSL30_libcrypto_so.OpenSSL_version();
+                var ptr = InteropOpenSSL3_libcrypto_so.OpenSSL_version();
                 if (ptr != IntPtr.Zero)
                     return LibraryName.libcrypto_so;
             }
@@ -384,18 +359,7 @@ namespace FasterHashing
 
             try
             {
-                var ptr = InteropOpenSSL30_libcrypto_so_3.OpenSSL_version();
-                if (ptr != IntPtr.Zero)
-                    return LibraryName.libcrypto_so_3;
-            }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3 from libcrypto.so.3: {ex}");
-            }
-
-            try
-            {
-                var ptr = InteropOpenSSL30_libcrypto_3_dll.OpenSSL_version();
+                var ptr = InteropOpenSSL3_libcrypto_3_dll.OpenSSL_version();
                 if (ptr != IntPtr.Zero)
                     return LibraryName.libcrypto_3_dll;
             }
@@ -406,7 +370,7 @@ namespace FasterHashing
 
             try
             {
-                var ptr = InteropOpenSSL30_libcrypto_3_x64_dll.OpenSSL_version();
+                var ptr = InteropOpenSSL3_libcrypto_3_x64_dll.OpenSSL_version();
                 if (ptr != IntPtr.Zero)
                     return LibraryName.libcrypto_3_x64_dll;
             }
@@ -417,24 +381,35 @@ namespace FasterHashing
 
             try
             {
-                var ptr = InteropOpenSSL30_libssl_3_dll.OpenSSL_version();
+                var ptr = InteropOpenSSL3_libssl.OpenSSL_version();
                 if (ptr != IntPtr.Zero)
-                    return LibraryName.libssl_3_dll;
+                    return LibraryName.libssl;
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3 from libssl-3.dll: {ex}");
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3 from libssl.so.3: {ex}");
+            }
+            
+            try
+            {
+                var ptr = InteropOpenSSL3_libssl_so_3.OpenSSL_version();
+                if (ptr != IntPtr.Zero)
+                    return LibraryName.libssl_so_3;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3 from libssl.so.3: {ex}");
             }
 
             try
             {
-                var ptr = InteropOpenSSL30_libssl_3_x64_dll.OpenSSL_version();
+                var ptr = InteropOpenSSL3_libcrypto_so_3.OpenSSL_version();
                 if (ptr != IntPtr.Zero)
-                    return LibraryName.libssl_3_x64_dll;
+                    return LibraryName.libcrypto_so_3;
             }
             catch (Exception ex)
             {
-                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3 from libssl-3-x64.dll: {ex}");
+                System.Diagnostics.Trace.WriteLine($"Failed to load OpenSSL3 from libcrypto.so.3: {ex}");
             }
 
             return LibraryName.libssl;

--- a/FasterHashing/OpenSSLImplementations.cs
+++ b/FasterHashing/OpenSSLImplementations.cs
@@ -9860,9 +9860,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// Implementation of a hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_HashAlgorithm : HashAlgorithm
+    public class OpenSSL3_libssl_HashAlgorithm : HashAlgorithm
     {
 
         /// <summary>
@@ -9880,16 +9880,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithm"/> class.
         /// </summary>
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-        public OpenSSL30_libssl_HashAlgorithm(string algorithm)
+        public OpenSSL3_libssl_HashAlgorithm(string algorithm)
         {
-            m_digestmethod = InteropOpenSSL30_libssl.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libssl.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -9900,7 +9900,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libssl.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -9908,10 +9908,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl.EVP_MD_CTX_new();
+                InteropOpenSSL3_libssl.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libssl.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -9929,7 +9929,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -9941,7 +9941,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -9951,7 +9951,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -9969,7 +9969,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -9977,9 +9977,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithm"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_HashAlgorithm()
+        ~OpenSSL3_libssl_HashAlgorithm()
         {
             Dispose(false);
         }
@@ -9992,7 +9992,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libssl.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -10000,22 +10000,22 @@ namespace FasterHashing
         }
 
         /// <summary>
-        /// Creates a new hash algorithm using an OpenSSL30 implementation
+        /// Creates a new hash algorithm using an OpenSSL3 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_HashAlgorithmMD5();
+                return new OpenSSL3_libssl_HashAlgorithmMD5();
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_HashAlgorithmSHA1();
+                return new OpenSSL3_libssl_HashAlgorithmSHA1();
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_HashAlgorithmSHA256();
+                return new OpenSSL3_libssl_HashAlgorithmSHA256();
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_HashAlgorithmSHA384();
+                return new OpenSSL3_libssl_HashAlgorithmSHA384();
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_HashAlgorithmSHA512();
-            try { return new OpenSSL30_libssl_HashAlgorithm(name); }
+                return new OpenSSL3_libssl_HashAlgorithmSHA512();
+            try { return new OpenSSL3_libssl_HashAlgorithm(name); }
             catch { }
 
             return null;
@@ -10024,9 +10024,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// Implementation of a hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_so_3_HashAlgorithm : HashAlgorithm
+    public class OpenSSL3_libssl_so_3_HashAlgorithm : HashAlgorithm
     {
 
         /// <summary>
@@ -10044,16 +10044,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithm"/> class.
         /// </summary>
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-        public OpenSSL30_libssl_so_3_HashAlgorithm(string algorithm)
+        public OpenSSL3_libssl_so_3_HashAlgorithm(string algorithm)
         {
-            m_digestmethod = InteropOpenSSL30_libssl_so_3.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libssl_so_3.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_so_3.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libssl_so_3.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -10064,7 +10064,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -10072,10 +10072,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_new();
+                InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -10093,7 +10093,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -10105,7 +10105,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -10115,7 +10115,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -10133,7 +10133,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -10141,9 +10141,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithm"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_so_3_HashAlgorithm()
+        ~OpenSSL3_libssl_so_3_HashAlgorithm()
         {
             Dispose(false);
         }
@@ -10156,7 +10156,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -10164,22 +10164,22 @@ namespace FasterHashing
         }
 
         /// <summary>
-        /// Creates a new hash algorithm using an OpenSSL30 implementation
+        /// Creates a new hash algorithm using an OpenSSL3 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_so_3_HashAlgorithmMD5();
+                return new OpenSSL3_libssl_so_3_HashAlgorithmMD5();
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_so_3_HashAlgorithmSHA1();
+                return new OpenSSL3_libssl_so_3_HashAlgorithmSHA1();
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_so_3_HashAlgorithmSHA256();
+                return new OpenSSL3_libssl_so_3_HashAlgorithmSHA256();
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_so_3_HashAlgorithmSHA384();
+                return new OpenSSL3_libssl_so_3_HashAlgorithmSHA384();
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_so_3_HashAlgorithmSHA512();
-            try { return new OpenSSL30_libssl_so_3_HashAlgorithm(name); }
+                return new OpenSSL3_libssl_so_3_HashAlgorithmSHA512();
+            try { return new OpenSSL3_libssl_so_3_HashAlgorithm(name); }
             catch { }
 
             return null;
@@ -10188,9 +10188,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// Implementation of a hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_so_HashAlgorithm : HashAlgorithm
+    public class OpenSSL3_libcrypto_so_HashAlgorithm : HashAlgorithm
     {
 
         /// <summary>
@@ -10208,16 +10208,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithm"/> class.
         /// </summary>
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-        public OpenSSL30_libcrypto_so_HashAlgorithm(string algorithm)
+        public OpenSSL3_libcrypto_so_HashAlgorithm(string algorithm)
         {
-            m_digestmethod = InteropOpenSSL30_libcrypto_so.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_so.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libcrypto_so.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_so.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -10228,7 +10228,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -10236,10 +10236,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -10257,7 +10257,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -10269,7 +10269,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -10279,7 +10279,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -10297,7 +10297,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -10305,9 +10305,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithm"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libcrypto_so_HashAlgorithm()
+        ~OpenSSL3_libcrypto_so_HashAlgorithm()
         {
             Dispose(false);
         }
@@ -10320,7 +10320,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -10328,22 +10328,22 @@ namespace FasterHashing
         }
 
         /// <summary>
-        /// Creates a new hash algorithm using an OpenSSL30 implementation
+        /// Creates a new hash algorithm using an OpenSSL3 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_so_HashAlgorithmMD5();
+                return new OpenSSL3_libcrypto_so_HashAlgorithmMD5();
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_so_HashAlgorithmSHA1();
+                return new OpenSSL3_libcrypto_so_HashAlgorithmSHA1();
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_so_HashAlgorithmSHA256();
+                return new OpenSSL3_libcrypto_so_HashAlgorithmSHA256();
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_so_HashAlgorithmSHA384();
+                return new OpenSSL3_libcrypto_so_HashAlgorithmSHA384();
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_so_HashAlgorithmSHA512();
-            try { return new OpenSSL30_libcrypto_so_HashAlgorithm(name); }
+                return new OpenSSL3_libcrypto_so_HashAlgorithmSHA512();
+            try { return new OpenSSL3_libcrypto_so_HashAlgorithm(name); }
             catch { }
 
             return null;
@@ -10352,9 +10352,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// Implementation of a hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_so_3_HashAlgorithm : HashAlgorithm
+    public class OpenSSL3_libcrypto_so_3_HashAlgorithm : HashAlgorithm
     {
 
         /// <summary>
@@ -10372,16 +10372,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithm"/> class.
         /// </summary>
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-        public OpenSSL30_libcrypto_so_3_HashAlgorithm(string algorithm)
+        public OpenSSL3_libcrypto_so_3_HashAlgorithm(string algorithm)
         {
-            m_digestmethod = InteropOpenSSL30_libcrypto_so_3.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_so_3.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libcrypto_so_3.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_so_3.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -10392,7 +10392,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -10400,10 +10400,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -10421,7 +10421,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -10433,7 +10433,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -10443,7 +10443,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -10461,7 +10461,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -10469,9 +10469,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithm"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libcrypto_so_3_HashAlgorithm()
+        ~OpenSSL3_libcrypto_so_3_HashAlgorithm()
         {
             Dispose(false);
         }
@@ -10484,7 +10484,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -10492,22 +10492,22 @@ namespace FasterHashing
         }
 
         /// <summary>
-        /// Creates a new hash algorithm using an OpenSSL30 implementation
+        /// Creates a new hash algorithm using an OpenSSL3 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_so_3_HashAlgorithmMD5();
+                return new OpenSSL3_libcrypto_so_3_HashAlgorithmMD5();
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_so_3_HashAlgorithmSHA1();
+                return new OpenSSL3_libcrypto_so_3_HashAlgorithmSHA1();
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_so_3_HashAlgorithmSHA256();
+                return new OpenSSL3_libcrypto_so_3_HashAlgorithmSHA256();
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_so_3_HashAlgorithmSHA384();
+                return new OpenSSL3_libcrypto_so_3_HashAlgorithmSHA384();
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_so_3_HashAlgorithmSHA512();
-            try { return new OpenSSL30_libcrypto_so_3_HashAlgorithm(name); }
+                return new OpenSSL3_libcrypto_so_3_HashAlgorithmSHA512();
+            try { return new OpenSSL3_libcrypto_so_3_HashAlgorithm(name); }
             catch { }
 
             return null;
@@ -10516,9 +10516,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// Implementation of a hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_3_dll_HashAlgorithm : HashAlgorithm
+    public class OpenSSL3_libcrypto_3_dll_HashAlgorithm : HashAlgorithm
     {
 
         /// <summary>
@@ -10536,16 +10536,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithm"/> class.
         /// </summary>
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-        public OpenSSL30_libssl_3_dll_HashAlgorithm(string algorithm)
+        public OpenSSL3_libcrypto_3_dll_HashAlgorithm(string algorithm)
         {
-            m_digestmethod = InteropOpenSSL30_libssl_3_dll.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_3_dll.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -10556,7 +10556,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_dll.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -10564,10 +10564,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -10585,7 +10585,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -10597,7 +10597,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -10607,7 +10607,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -10625,7 +10625,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -10633,9 +10633,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithm"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_3_dll_HashAlgorithm()
+        ~OpenSSL3_libcrypto_3_dll_HashAlgorithm()
         {
             Dispose(false);
         }
@@ -10648,7 +10648,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -10656,22 +10656,22 @@ namespace FasterHashing
         }
 
         /// <summary>
-        /// Creates a new hash algorithm using an OpenSSL30 implementation
+        /// Creates a new hash algorithm using an OpenSSL3 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_3_dll_HashAlgorithmMD5();
+                return new OpenSSL3_libcrypto_3_dll_HashAlgorithmMD5();
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_3_dll_HashAlgorithmSHA1();
+                return new OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA1();
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_3_dll_HashAlgorithmSHA256();
+                return new OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA256();
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_3_dll_HashAlgorithmSHA384();
+                return new OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA384();
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_3_dll_HashAlgorithmSHA512();
-            try { return new OpenSSL30_libssl_3_dll_HashAlgorithm(name); }
+                return new OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA512();
+            try { return new OpenSSL3_libcrypto_3_dll_HashAlgorithm(name); }
             catch { }
 
             return null;
@@ -10680,9 +10680,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// Implementation of a hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_3_x64_dll_HashAlgorithm : HashAlgorithm
+    public class OpenSSL3_libcrypto_3_x64_dll_HashAlgorithm : HashAlgorithm
     {
 
         /// <summary>
@@ -10700,16 +10700,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithm"/> class.
         /// </summary>
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-        public OpenSSL30_libssl_3_x64_dll_HashAlgorithm(string algorithm)
+        public OpenSSL3_libcrypto_3_x64_dll_HashAlgorithm(string algorithm)
         {
-            m_digestmethod = InteropOpenSSL30_libssl_3_x64_dll.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -10720,7 +10720,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -10728,10 +10728,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -10749,7 +10749,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -10761,7 +10761,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -10771,7 +10771,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -10789,7 +10789,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -10797,9 +10797,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithm"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_3_x64_dll_HashAlgorithm()
+        ~OpenSSL3_libcrypto_3_x64_dll_HashAlgorithm()
         {
             Dispose(false);
         }
@@ -10812,7 +10812,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -10820,22 +10820,22 @@ namespace FasterHashing
         }
 
         /// <summary>
-        /// Creates a new hash algorithm using an OpenSSL30 implementation
+        /// Creates a new hash algorithm using an OpenSSL3 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_3_x64_dll_HashAlgorithmMD5();
+                return new OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmMD5();
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA1();
+                return new OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA1();
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA256();
+                return new OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA256();
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA384();
+                return new OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA384();
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA512();
-            try { return new OpenSSL30_libssl_3_x64_dll_HashAlgorithm(name); }
+                return new OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA512();
+            try { return new OpenSSL3_libcrypto_3_x64_dll_HashAlgorithm(name); }
             catch { }
 
             return null;
@@ -10844,9 +10844,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// Implementation of the MD5 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_3_dll_HashAlgorithm : HashAlgorithm
+    public class OpenSSL3_libssl_HashAlgorithmMD5 : MD5
     {
 
         /// <summary>
@@ -10864,344 +10864,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmMD5"/> class.
         /// </summary>
-        /// <param name="algorithm">The name of the hash algorithm to use.</param>
-        public OpenSSL30_libcrypto_3_dll_HashAlgorithm(string algorithm)
-        {
-            m_digestmethod = InteropOpenSSL30_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
-            if (m_digestmethod == IntPtr.Zero)
-                throw new ArgumentException($"No such algorithm: {algorithm}");
-
-            m_size = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
-        }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int OutputBlockSize { get { return m_size; } }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
-
-        /// <summary>
-        /// Initializes the hashing algorithm
-        /// </summary>
-        public override void Initialize()
-        {
-            if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_new();
-
-            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-        }
-
-        /// <summary>
-        /// Performs the core hashing
-        /// </summary>
-        /// <param name="array">The data to hash.</param>
-        /// <param name="ibStart">The index into the array where hashing starts.</param>
-        /// <param name="cbSize">The number of bytes to hash.</param>
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            // Common case is to use offset=0, and here we can rely on the system marshaller to work
-            if (ibStart == 0)
-            {
-                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#if AVOID_PINNING_SMALL_ARRAYS
-            // For small chunks, we can copy and get mostly the same performance as the managed version
-            else if (cbSize < 1024)
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-
-                var tmp = new byte[cbSize];
-                Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#endif
-            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
-            else
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
-                pa.Free();
-                if (res != 1)
-                   throw new Win32Exception(Marshal.GetLastWin32Error());
-           }
-        }
-
-        /// <summary>
-        /// Computes the final hash and returns the result
-        /// </summary>
-        /// <returns>The final messge digest.</returns>
-        protected override byte[] HashFinal()
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            var res = new byte[m_size];
-            var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-
-            return res;
-        }
-
-        /// <summary>
-        /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
-        /// </summary>
-        ~OpenSSL30_libcrypto_3_dll_HashAlgorithm()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Dispose the this instance.
-        /// </summary>
-        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (m_context != IntPtr.Zero)
-            {
-                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
-                m_context = IntPtr.Zero;
-            }
-
-            base.Dispose(disposing);
-        }
-
-        /// <summary>
-        /// Creates a new hash algorithm using an OpenSSL30 implementation
-        /// </summary>
-        /// <param name-"name">The name of the algorithm to create</param>
-        public static new HashAlgorithm Create(string name)
-        {
-            if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_3_dll_HashAlgorithmMD5();
-            if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA1();
-            if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA256();
-            if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA384();
-            if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA512();
-            try { return new OpenSSL30_libcrypto_3_dll_HashAlgorithm(name); }
-            catch { }
-
-            return null;
-        }
-    }
-
-
-    /// <summary>
-    /// Implementation of a hash algorithm, using OpenSSL 3.0
-    /// </summary>
-    public class OpenSSL30_libcrypto_3_x64_dll_HashAlgorithm : HashAlgorithm
-    {
-
-        /// <summary>
-        /// The message digest context
-        /// </summary>
-        private IntPtr m_context;
-
-        /// <summary>
-        /// The size of the message digest
-        /// </summary>
-        private readonly int m_size;
-        /// <summary>
-        /// The message digest method
-        /// </summary>
-        private readonly IntPtr m_digestmethod;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
-        /// </summary>
-        /// <param name="algorithm">The name of the hash algorithm to use.</param>
-        public OpenSSL30_libcrypto_3_x64_dll_HashAlgorithm(string algorithm)
-        {
-            m_digestmethod = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
-            if (m_digestmethod == IntPtr.Zero)
-                throw new ArgumentException($"No such algorithm: {algorithm}");
-
-            m_size = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
-        }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int OutputBlockSize { get { return m_size; } }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
-
-        /// <summary>
-        /// Initializes the hashing algorithm
-        /// </summary>
-        public override void Initialize()
-        {
-            if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_new();
-
-            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-        }
-
-        /// <summary>
-        /// Performs the core hashing
-        /// </summary>
-        /// <param name="array">The data to hash.</param>
-        /// <param name="ibStart">The index into the array where hashing starts.</param>
-        /// <param name="cbSize">The number of bytes to hash.</param>
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            // Common case is to use offset=0, and here we can rely on the system marshaller to work
-            if (ibStart == 0)
-            {
-                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#if AVOID_PINNING_SMALL_ARRAYS
-            // For small chunks, we can copy and get mostly the same performance as the managed version
-            else if (cbSize < 1024)
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-
-                var tmp = new byte[cbSize];
-                Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#endif
-            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
-            else
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
-                pa.Free();
-                if (res != 1)
-                   throw new Win32Exception(Marshal.GetLastWin32Error());
-           }
-        }
-
-        /// <summary>
-        /// Computes the final hash and returns the result
-        /// </summary>
-        /// <returns>The final messge digest.</returns>
-        protected override byte[] HashFinal()
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            var res = new byte[m_size];
-            var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-
-            return res;
-        }
-
-        /// <summary>
-        /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
-        /// </summary>
-        ~OpenSSL30_libcrypto_3_x64_dll_HashAlgorithm()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Dispose the this instance.
-        /// </summary>
-        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (m_context != IntPtr.Zero)
-            {
-                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
-                m_context = IntPtr.Zero;
-            }
-
-            base.Dispose(disposing);
-        }
-
-        /// <summary>
-        /// Creates a new hash algorithm using an OpenSSL30 implementation
-        /// </summary>
-        /// <param name-"name">The name of the algorithm to create</param>
-        public static new HashAlgorithm Create(string name)
-        {
-            if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmMD5();
-            if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA1();
-            if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA256();
-            if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA384();
-            if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
-                return new OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA512();
-            try { return new OpenSSL30_libcrypto_3_x64_dll_HashAlgorithm(name); }
-            catch { }
-
-            return null;
-        }
-    }
-
-
-    /// <summary>
-    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
-    /// </summary>
-    public class OpenSSL30_libssl_HashAlgorithmMD5 : MD5
-    {
-
-        /// <summary>
-        /// The message digest context
-        /// </summary>
-        private IntPtr m_context;
-
-        /// <summary>
-        /// The size of the message digest
-        /// </summary>
-        private readonly int m_size;
-        /// <summary>
-        /// The message digest method
-        /// </summary>
-        private readonly IntPtr m_digestmethod;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
-        /// </summary>
-        public OpenSSL30_libssl_HashAlgorithmMD5()
+        public OpenSSL3_libssl_HashAlgorithmMD5()
         {
            var algorithm = "MD5";
-            m_digestmethod = InteropOpenSSL30_libssl.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libssl.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -11212,7 +10884,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libssl.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -11220,10 +10892,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl.EVP_MD_CTX_new();
+                InteropOpenSSL3_libssl.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libssl.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -11241,7 +10913,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -11253,7 +10925,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -11263,7 +10935,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -11281,7 +10953,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -11289,9 +10961,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmMD5"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_HashAlgorithmMD5()
+        ~OpenSSL3_libssl_HashAlgorithmMD5()
         {
             Dispose(false);
         }
@@ -11304,7 +10976,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libssl.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -11314,9 +10986,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the MD5 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_so_3_HashAlgorithmMD5 : MD5
+    public class OpenSSL3_libssl_so_3_HashAlgorithmMD5 : MD5
     {
 
         /// <summary>
@@ -11334,16 +11006,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmMD5"/> class.
         /// </summary>
-        public OpenSSL30_libssl_so_3_HashAlgorithmMD5()
+        public OpenSSL3_libssl_so_3_HashAlgorithmMD5()
         {
            var algorithm = "MD5";
-            m_digestmethod = InteropOpenSSL30_libssl_so_3.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libssl_so_3.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_so_3.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libssl_so_3.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -11354,7 +11026,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -11362,10 +11034,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_new();
+                InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -11383,7 +11055,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -11395,7 +11067,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -11405,7 +11077,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -11423,7 +11095,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -11431,9 +11103,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmMD5"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_so_3_HashAlgorithmMD5()
+        ~OpenSSL3_libssl_so_3_HashAlgorithmMD5()
         {
             Dispose(false);
         }
@@ -11446,7 +11118,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -11456,9 +11128,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the MD5 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_so_HashAlgorithmMD5 : MD5
+    public class OpenSSL3_libcrypto_so_HashAlgorithmMD5 : MD5
     {
 
         /// <summary>
@@ -11476,16 +11148,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmMD5"/> class.
         /// </summary>
-        public OpenSSL30_libcrypto_so_HashAlgorithmMD5()
+        public OpenSSL3_libcrypto_so_HashAlgorithmMD5()
         {
            var algorithm = "MD5";
-            m_digestmethod = InteropOpenSSL30_libcrypto_so.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_so.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libcrypto_so.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_so.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -11496,7 +11168,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -11504,10 +11176,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -11525,7 +11197,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -11537,7 +11209,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -11547,7 +11219,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -11565,7 +11237,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -11573,9 +11245,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmMD5"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libcrypto_so_HashAlgorithmMD5()
+        ~OpenSSL3_libcrypto_so_HashAlgorithmMD5()
         {
             Dispose(false);
         }
@@ -11588,7 +11260,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -11598,9 +11270,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the MD5 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_so_3_HashAlgorithmMD5 : MD5
+    public class OpenSSL3_libcrypto_so_3_HashAlgorithmMD5 : MD5
     {
 
         /// <summary>
@@ -11618,16 +11290,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmMD5"/> class.
         /// </summary>
-        public OpenSSL30_libcrypto_so_3_HashAlgorithmMD5()
+        public OpenSSL3_libcrypto_so_3_HashAlgorithmMD5()
         {
            var algorithm = "MD5";
-            m_digestmethod = InteropOpenSSL30_libcrypto_so_3.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_so_3.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libcrypto_so_3.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_so_3.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -11638,7 +11310,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -11646,10 +11318,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -11667,7 +11339,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -11679,7 +11351,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -11689,7 +11361,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -11707,7 +11379,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -11715,9 +11387,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmMD5"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libcrypto_so_3_HashAlgorithmMD5()
+        ~OpenSSL3_libcrypto_so_3_HashAlgorithmMD5()
         {
             Dispose(false);
         }
@@ -11730,7 +11402,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -11740,9 +11412,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the MD5 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_3_dll_HashAlgorithmMD5 : MD5
+    public class OpenSSL3_libcrypto_3_dll_HashAlgorithmMD5 : MD5
     {
 
         /// <summary>
@@ -11760,16 +11432,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmMD5"/> class.
         /// </summary>
-        public OpenSSL30_libssl_3_dll_HashAlgorithmMD5()
+        public OpenSSL3_libcrypto_3_dll_HashAlgorithmMD5()
         {
            var algorithm = "MD5";
-            m_digestmethod = InteropOpenSSL30_libssl_3_dll.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_3_dll.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -11780,7 +11452,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_dll.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -11788,10 +11460,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -11809,7 +11481,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -11821,7 +11493,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -11831,7 +11503,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -11849,7 +11521,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -11857,9 +11529,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmMD5"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_3_dll_HashAlgorithmMD5()
+        ~OpenSSL3_libcrypto_3_dll_HashAlgorithmMD5()
         {
             Dispose(false);
         }
@@ -11872,7 +11544,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -11882,9 +11554,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the MD5 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_3_x64_dll_HashAlgorithmMD5 : MD5
+    public class OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmMD5 : MD5
     {
 
         /// <summary>
@@ -11902,16 +11574,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmMD5"/> class.
         /// </summary>
-        public OpenSSL30_libssl_3_x64_dll_HashAlgorithmMD5()
+        public OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmMD5()
         {
            var algorithm = "MD5";
-            m_digestmethod = InteropOpenSSL30_libssl_3_x64_dll.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -11922,7 +11594,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -11930,10 +11602,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -11951,7 +11623,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -11963,7 +11635,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -11973,7 +11645,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -11991,7 +11663,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -11999,9 +11671,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmMD5"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_3_x64_dll_HashAlgorithmMD5()
+        ~OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmMD5()
         {
             Dispose(false);
         }
@@ -12014,7 +11686,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -12024,9 +11696,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_3_dll_HashAlgorithmMD5 : MD5
+    public class OpenSSL3_libssl_HashAlgorithmSHA1 : SHA1
     {
 
         /// <summary>
@@ -12044,300 +11716,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA1"/> class.
         /// </summary>
-        public OpenSSL30_libcrypto_3_dll_HashAlgorithmMD5()
-        {
-           var algorithm = "MD5";
-            m_digestmethod = InteropOpenSSL30_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
-            if (m_digestmethod == IntPtr.Zero)
-                throw new ArgumentException($"No such algorithm: {algorithm}");
-
-            m_size = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
-        }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int OutputBlockSize { get { return m_size; } }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
-
-        /// <summary>
-        /// Initializes the hashing algorithm
-        /// </summary>
-        public override void Initialize()
-        {
-            if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_new();
-
-            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-        }
-
-        /// <summary>
-        /// Performs the core hashing
-        /// </summary>
-        /// <param name="array">The data to hash.</param>
-        /// <param name="ibStart">The index into the array where hashing starts.</param>
-        /// <param name="cbSize">The number of bytes to hash.</param>
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            // Common case is to use offset=0, and here we can rely on the system marshaller to work
-            if (ibStart == 0)
-            {
-                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#if AVOID_PINNING_SMALL_ARRAYS
-            // For small chunks, we can copy and get mostly the same performance as the managed version
-            else if (cbSize < 1024)
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-
-                var tmp = new byte[cbSize];
-                Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#endif
-            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
-            else
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
-                pa.Free();
-                if (res != 1)
-                   throw new Win32Exception(Marshal.GetLastWin32Error());
-           }
-        }
-
-        /// <summary>
-        /// Computes the final hash and returns the result
-        /// </summary>
-        /// <returns>The final messge digest.</returns>
-        protected override byte[] HashFinal()
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            var res = new byte[m_size];
-            var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-
-            return res;
-        }
-
-        /// <summary>
-        /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
-        /// </summary>
-        ~OpenSSL30_libcrypto_3_dll_HashAlgorithmMD5()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Dispose the this instance.
-        /// </summary>
-        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (m_context != IntPtr.Zero)
-            {
-                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
-                m_context = IntPtr.Zero;
-            }
-
-            base.Dispose(disposing);
-        }
-    }
-
-
-    /// <summary>
-    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
-    /// </summary>
-    public class OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmMD5 : MD5
-    {
-
-        /// <summary>
-        /// The message digest context
-        /// </summary>
-        private IntPtr m_context;
-
-        /// <summary>
-        /// The size of the message digest
-        /// </summary>
-        private readonly int m_size;
-        /// <summary>
-        /// The message digest method
-        /// </summary>
-        private readonly IntPtr m_digestmethod;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
-        /// </summary>
-        public OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmMD5()
-        {
-           var algorithm = "MD5";
-            m_digestmethod = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
-            if (m_digestmethod == IntPtr.Zero)
-                throw new ArgumentException($"No such algorithm: {algorithm}");
-
-            m_size = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
-        }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int OutputBlockSize { get { return m_size; } }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
-
-        /// <summary>
-        /// Initializes the hashing algorithm
-        /// </summary>
-        public override void Initialize()
-        {
-            if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_new();
-
-            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-        }
-
-        /// <summary>
-        /// Performs the core hashing
-        /// </summary>
-        /// <param name="array">The data to hash.</param>
-        /// <param name="ibStart">The index into the array where hashing starts.</param>
-        /// <param name="cbSize">The number of bytes to hash.</param>
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            // Common case is to use offset=0, and here we can rely on the system marshaller to work
-            if (ibStart == 0)
-            {
-                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#if AVOID_PINNING_SMALL_ARRAYS
-            // For small chunks, we can copy and get mostly the same performance as the managed version
-            else if (cbSize < 1024)
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-
-                var tmp = new byte[cbSize];
-                Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#endif
-            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
-            else
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
-                pa.Free();
-                if (res != 1)
-                   throw new Win32Exception(Marshal.GetLastWin32Error());
-           }
-        }
-
-        /// <summary>
-        /// Computes the final hash and returns the result
-        /// </summary>
-        /// <returns>The final messge digest.</returns>
-        protected override byte[] HashFinal()
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            var res = new byte[m_size];
-            var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-
-            return res;
-        }
-
-        /// <summary>
-        /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
-        /// </summary>
-        ~OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmMD5()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Dispose the this instance.
-        /// </summary>
-        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (m_context != IntPtr.Zero)
-            {
-                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
-                m_context = IntPtr.Zero;
-            }
-
-            base.Dispose(disposing);
-        }
-    }
-
-
-    /// <summary>
-    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
-    /// </summary>
-    public class OpenSSL30_libssl_HashAlgorithmSHA1 : SHA1
-    {
-
-        /// <summary>
-        /// The message digest context
-        /// </summary>
-        private IntPtr m_context;
-
-        /// <summary>
-        /// The size of the message digest
-        /// </summary>
-        private readonly int m_size;
-        /// <summary>
-        /// The message digest method
-        /// </summary>
-        private readonly IntPtr m_digestmethod;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
-        /// </summary>
-        public OpenSSL30_libssl_HashAlgorithmSHA1()
+        public OpenSSL3_libssl_HashAlgorithmSHA1()
         {
            var algorithm = "SHA1";
-            m_digestmethod = InteropOpenSSL30_libssl.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libssl.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -12348,7 +11736,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libssl.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -12356,10 +11744,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl.EVP_MD_CTX_new();
+                InteropOpenSSL3_libssl.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libssl.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -12377,7 +11765,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -12389,7 +11777,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -12399,7 +11787,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -12417,7 +11805,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -12425,9 +11813,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA1"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_HashAlgorithmSHA1()
+        ~OpenSSL3_libssl_HashAlgorithmSHA1()
         {
             Dispose(false);
         }
@@ -12440,7 +11828,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libssl.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -12450,9 +11838,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_so_3_HashAlgorithmSHA1 : SHA1
+    public class OpenSSL3_libssl_so_3_HashAlgorithmSHA1 : SHA1
     {
 
         /// <summary>
@@ -12470,16 +11858,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA1"/> class.
         /// </summary>
-        public OpenSSL30_libssl_so_3_HashAlgorithmSHA1()
+        public OpenSSL3_libssl_so_3_HashAlgorithmSHA1()
         {
            var algorithm = "SHA1";
-            m_digestmethod = InteropOpenSSL30_libssl_so_3.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libssl_so_3.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_so_3.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libssl_so_3.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -12490,7 +11878,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -12498,10 +11886,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_new();
+                InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -12519,7 +11907,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -12531,7 +11919,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -12541,7 +11929,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -12559,7 +11947,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -12567,9 +11955,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA1"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_so_3_HashAlgorithmSHA1()
+        ~OpenSSL3_libssl_so_3_HashAlgorithmSHA1()
         {
             Dispose(false);
         }
@@ -12582,7 +11970,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -12592,9 +11980,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_so_HashAlgorithmSHA1 : SHA1
+    public class OpenSSL3_libcrypto_so_HashAlgorithmSHA1 : SHA1
     {
 
         /// <summary>
@@ -12612,16 +12000,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA1"/> class.
         /// </summary>
-        public OpenSSL30_libcrypto_so_HashAlgorithmSHA1()
+        public OpenSSL3_libcrypto_so_HashAlgorithmSHA1()
         {
            var algorithm = "SHA1";
-            m_digestmethod = InteropOpenSSL30_libcrypto_so.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_so.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libcrypto_so.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_so.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -12632,7 +12020,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -12640,10 +12028,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -12661,7 +12049,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -12673,7 +12061,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -12683,7 +12071,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -12701,7 +12089,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -12709,9 +12097,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA1"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libcrypto_so_HashAlgorithmSHA1()
+        ~OpenSSL3_libcrypto_so_HashAlgorithmSHA1()
         {
             Dispose(false);
         }
@@ -12724,7 +12112,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -12734,9 +12122,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_so_3_HashAlgorithmSHA1 : SHA1
+    public class OpenSSL3_libcrypto_so_3_HashAlgorithmSHA1 : SHA1
     {
 
         /// <summary>
@@ -12754,16 +12142,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA1"/> class.
         /// </summary>
-        public OpenSSL30_libcrypto_so_3_HashAlgorithmSHA1()
+        public OpenSSL3_libcrypto_so_3_HashAlgorithmSHA1()
         {
            var algorithm = "SHA1";
-            m_digestmethod = InteropOpenSSL30_libcrypto_so_3.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_so_3.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libcrypto_so_3.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_so_3.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -12774,7 +12162,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -12782,10 +12170,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -12803,7 +12191,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -12815,7 +12203,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -12825,7 +12213,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -12843,7 +12231,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -12851,9 +12239,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA1"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libcrypto_so_3_HashAlgorithmSHA1()
+        ~OpenSSL3_libcrypto_so_3_HashAlgorithmSHA1()
         {
             Dispose(false);
         }
@@ -12866,7 +12254,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -12876,9 +12264,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_3_dll_HashAlgorithmSHA1 : SHA1
+    public class OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA1 : SHA1
     {
 
         /// <summary>
@@ -12896,16 +12284,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA1"/> class.
         /// </summary>
-        public OpenSSL30_libssl_3_dll_HashAlgorithmSHA1()
+        public OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA1()
         {
            var algorithm = "SHA1";
-            m_digestmethod = InteropOpenSSL30_libssl_3_dll.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_3_dll.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -12916,7 +12304,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_dll.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -12924,10 +12312,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -12945,7 +12333,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -12957,7 +12345,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -12967,7 +12355,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -12985,7 +12373,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -12993,9 +12381,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA1"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_3_dll_HashAlgorithmSHA1()
+        ~OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA1()
         {
             Dispose(false);
         }
@@ -13008,7 +12396,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -13018,9 +12406,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA1 : SHA1
+    public class OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA1 : SHA1
     {
 
         /// <summary>
@@ -13038,16 +12426,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA1"/> class.
         /// </summary>
-        public OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA1()
+        public OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA1()
         {
            var algorithm = "SHA1";
-            m_digestmethod = InteropOpenSSL30_libssl_3_x64_dll.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -13058,7 +12446,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -13066,10 +12454,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -13087,7 +12475,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -13099,7 +12487,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -13109,7 +12497,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -13127,7 +12515,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -13135,9 +12523,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA1"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA1()
+        ~OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA1()
         {
             Dispose(false);
         }
@@ -13150,7 +12538,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -13160,9 +12548,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA1 : SHA1
+    public class OpenSSL3_libssl_HashAlgorithmSHA256 : SHA256
     {
 
         /// <summary>
@@ -13180,300 +12568,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA256"/> class.
         /// </summary>
-        public OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA1()
-        {
-           var algorithm = "SHA1";
-            m_digestmethod = InteropOpenSSL30_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
-            if (m_digestmethod == IntPtr.Zero)
-                throw new ArgumentException($"No such algorithm: {algorithm}");
-
-            m_size = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
-        }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int OutputBlockSize { get { return m_size; } }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
-
-        /// <summary>
-        /// Initializes the hashing algorithm
-        /// </summary>
-        public override void Initialize()
-        {
-            if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_new();
-
-            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-        }
-
-        /// <summary>
-        /// Performs the core hashing
-        /// </summary>
-        /// <param name="array">The data to hash.</param>
-        /// <param name="ibStart">The index into the array where hashing starts.</param>
-        /// <param name="cbSize">The number of bytes to hash.</param>
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            // Common case is to use offset=0, and here we can rely on the system marshaller to work
-            if (ibStart == 0)
-            {
-                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#if AVOID_PINNING_SMALL_ARRAYS
-            // For small chunks, we can copy and get mostly the same performance as the managed version
-            else if (cbSize < 1024)
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-
-                var tmp = new byte[cbSize];
-                Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#endif
-            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
-            else
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
-                pa.Free();
-                if (res != 1)
-                   throw new Win32Exception(Marshal.GetLastWin32Error());
-           }
-        }
-
-        /// <summary>
-        /// Computes the final hash and returns the result
-        /// </summary>
-        /// <returns>The final messge digest.</returns>
-        protected override byte[] HashFinal()
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            var res = new byte[m_size];
-            var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-
-            return res;
-        }
-
-        /// <summary>
-        /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
-        /// </summary>
-        ~OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA1()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Dispose the this instance.
-        /// </summary>
-        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (m_context != IntPtr.Zero)
-            {
-                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
-                m_context = IntPtr.Zero;
-            }
-
-            base.Dispose(disposing);
-        }
-    }
-
-
-    /// <summary>
-    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
-    /// </summary>
-    public class OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA1 : SHA1
-    {
-
-        /// <summary>
-        /// The message digest context
-        /// </summary>
-        private IntPtr m_context;
-
-        /// <summary>
-        /// The size of the message digest
-        /// </summary>
-        private readonly int m_size;
-        /// <summary>
-        /// The message digest method
-        /// </summary>
-        private readonly IntPtr m_digestmethod;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
-        /// </summary>
-        public OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA1()
-        {
-           var algorithm = "SHA1";
-            m_digestmethod = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
-            if (m_digestmethod == IntPtr.Zero)
-                throw new ArgumentException($"No such algorithm: {algorithm}");
-
-            m_size = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
-        }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int OutputBlockSize { get { return m_size; } }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
-
-        /// <summary>
-        /// Initializes the hashing algorithm
-        /// </summary>
-        public override void Initialize()
-        {
-            if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_new();
-
-            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-        }
-
-        /// <summary>
-        /// Performs the core hashing
-        /// </summary>
-        /// <param name="array">The data to hash.</param>
-        /// <param name="ibStart">The index into the array where hashing starts.</param>
-        /// <param name="cbSize">The number of bytes to hash.</param>
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            // Common case is to use offset=0, and here we can rely on the system marshaller to work
-            if (ibStart == 0)
-            {
-                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#if AVOID_PINNING_SMALL_ARRAYS
-            // For small chunks, we can copy and get mostly the same performance as the managed version
-            else if (cbSize < 1024)
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-
-                var tmp = new byte[cbSize];
-                Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#endif
-            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
-            else
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
-                pa.Free();
-                if (res != 1)
-                   throw new Win32Exception(Marshal.GetLastWin32Error());
-           }
-        }
-
-        /// <summary>
-        /// Computes the final hash and returns the result
-        /// </summary>
-        /// <returns>The final messge digest.</returns>
-        protected override byte[] HashFinal()
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            var res = new byte[m_size];
-            var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-
-            return res;
-        }
-
-        /// <summary>
-        /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
-        /// </summary>
-        ~OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA1()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Dispose the this instance.
-        /// </summary>
-        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (m_context != IntPtr.Zero)
-            {
-                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
-                m_context = IntPtr.Zero;
-            }
-
-            base.Dispose(disposing);
-        }
-    }
-
-
-    /// <summary>
-    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
-    /// </summary>
-    public class OpenSSL30_libssl_HashAlgorithmSHA256 : SHA256
-    {
-
-        /// <summary>
-        /// The message digest context
-        /// </summary>
-        private IntPtr m_context;
-
-        /// <summary>
-        /// The size of the message digest
-        /// </summary>
-        private readonly int m_size;
-        /// <summary>
-        /// The message digest method
-        /// </summary>
-        private readonly IntPtr m_digestmethod;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
-        /// </summary>
-        public OpenSSL30_libssl_HashAlgorithmSHA256()
+        public OpenSSL3_libssl_HashAlgorithmSHA256()
         {
            var algorithm = "SHA256";
-            m_digestmethod = InteropOpenSSL30_libssl.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libssl.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -13484,7 +12588,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libssl.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -13492,10 +12596,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl.EVP_MD_CTX_new();
+                InteropOpenSSL3_libssl.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libssl.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -13513,7 +12617,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -13525,7 +12629,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -13535,7 +12639,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -13553,7 +12657,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -13561,9 +12665,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA256"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_HashAlgorithmSHA256()
+        ~OpenSSL3_libssl_HashAlgorithmSHA256()
         {
             Dispose(false);
         }
@@ -13576,7 +12680,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libssl.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -13586,9 +12690,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_so_3_HashAlgorithmSHA256 : SHA256
+    public class OpenSSL3_libssl_so_3_HashAlgorithmSHA256 : SHA256
     {
 
         /// <summary>
@@ -13606,16 +12710,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA256"/> class.
         /// </summary>
-        public OpenSSL30_libssl_so_3_HashAlgorithmSHA256()
+        public OpenSSL3_libssl_so_3_HashAlgorithmSHA256()
         {
            var algorithm = "SHA256";
-            m_digestmethod = InteropOpenSSL30_libssl_so_3.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libssl_so_3.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_so_3.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libssl_so_3.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -13626,7 +12730,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -13634,10 +12738,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_new();
+                InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -13655,7 +12759,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -13667,7 +12771,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -13677,7 +12781,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -13695,7 +12799,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -13703,9 +12807,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA256"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_so_3_HashAlgorithmSHA256()
+        ~OpenSSL3_libssl_so_3_HashAlgorithmSHA256()
         {
             Dispose(false);
         }
@@ -13718,7 +12822,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -13728,9 +12832,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_so_HashAlgorithmSHA256 : SHA256
+    public class OpenSSL3_libcrypto_so_HashAlgorithmSHA256 : SHA256
     {
 
         /// <summary>
@@ -13748,16 +12852,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA256"/> class.
         /// </summary>
-        public OpenSSL30_libcrypto_so_HashAlgorithmSHA256()
+        public OpenSSL3_libcrypto_so_HashAlgorithmSHA256()
         {
            var algorithm = "SHA256";
-            m_digestmethod = InteropOpenSSL30_libcrypto_so.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_so.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libcrypto_so.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_so.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -13768,7 +12872,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -13776,10 +12880,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -13797,7 +12901,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -13809,7 +12913,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -13819,7 +12923,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -13837,7 +12941,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -13845,9 +12949,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA256"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libcrypto_so_HashAlgorithmSHA256()
+        ~OpenSSL3_libcrypto_so_HashAlgorithmSHA256()
         {
             Dispose(false);
         }
@@ -13860,7 +12964,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -13870,9 +12974,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_so_3_HashAlgorithmSHA256 : SHA256
+    public class OpenSSL3_libcrypto_so_3_HashAlgorithmSHA256 : SHA256
     {
 
         /// <summary>
@@ -13890,16 +12994,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA256"/> class.
         /// </summary>
-        public OpenSSL30_libcrypto_so_3_HashAlgorithmSHA256()
+        public OpenSSL3_libcrypto_so_3_HashAlgorithmSHA256()
         {
            var algorithm = "SHA256";
-            m_digestmethod = InteropOpenSSL30_libcrypto_so_3.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_so_3.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libcrypto_so_3.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_so_3.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -13910,7 +13014,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -13918,10 +13022,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -13939,7 +13043,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -13951,7 +13055,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -13961,7 +13065,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -13979,7 +13083,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -13987,9 +13091,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA256"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libcrypto_so_3_HashAlgorithmSHA256()
+        ~OpenSSL3_libcrypto_so_3_HashAlgorithmSHA256()
         {
             Dispose(false);
         }
@@ -14002,7 +13106,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -14012,9 +13116,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_3_dll_HashAlgorithmSHA256 : SHA256
+    public class OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA256 : SHA256
     {
 
         /// <summary>
@@ -14032,16 +13136,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA256"/> class.
         /// </summary>
-        public OpenSSL30_libssl_3_dll_HashAlgorithmSHA256()
+        public OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA256()
         {
            var algorithm = "SHA256";
-            m_digestmethod = InteropOpenSSL30_libssl_3_dll.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_3_dll.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -14052,7 +13156,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_dll.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -14060,10 +13164,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -14081,7 +13185,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -14093,7 +13197,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -14103,7 +13207,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -14121,7 +13225,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -14129,9 +13233,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA256"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_3_dll_HashAlgorithmSHA256()
+        ~OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA256()
         {
             Dispose(false);
         }
@@ -14144,7 +13248,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -14154,9 +13258,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA256 : SHA256
+    public class OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA256 : SHA256
     {
 
         /// <summary>
@@ -14174,16 +13278,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA256"/> class.
         /// </summary>
-        public OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA256()
+        public OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA256()
         {
            var algorithm = "SHA256";
-            m_digestmethod = InteropOpenSSL30_libssl_3_x64_dll.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -14194,7 +13298,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -14202,10 +13306,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -14223,7 +13327,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -14235,7 +13339,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -14245,7 +13349,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -14263,7 +13367,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -14271,9 +13375,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA256"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA256()
+        ~OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA256()
         {
             Dispose(false);
         }
@@ -14286,7 +13390,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -14296,9 +13400,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA256 : SHA256
+    public class OpenSSL3_libssl_HashAlgorithmSHA384 : SHA384
     {
 
         /// <summary>
@@ -14316,300 +13420,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA384"/> class.
         /// </summary>
-        public OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA256()
-        {
-           var algorithm = "SHA256";
-            m_digestmethod = InteropOpenSSL30_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
-            if (m_digestmethod == IntPtr.Zero)
-                throw new ArgumentException($"No such algorithm: {algorithm}");
-
-            m_size = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
-        }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int OutputBlockSize { get { return m_size; } }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
-
-        /// <summary>
-        /// Initializes the hashing algorithm
-        /// </summary>
-        public override void Initialize()
-        {
-            if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_new();
-
-            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-        }
-
-        /// <summary>
-        /// Performs the core hashing
-        /// </summary>
-        /// <param name="array">The data to hash.</param>
-        /// <param name="ibStart">The index into the array where hashing starts.</param>
-        /// <param name="cbSize">The number of bytes to hash.</param>
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            // Common case is to use offset=0, and here we can rely on the system marshaller to work
-            if (ibStart == 0)
-            {
-                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#if AVOID_PINNING_SMALL_ARRAYS
-            // For small chunks, we can copy and get mostly the same performance as the managed version
-            else if (cbSize < 1024)
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-
-                var tmp = new byte[cbSize];
-                Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#endif
-            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
-            else
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
-                pa.Free();
-                if (res != 1)
-                   throw new Win32Exception(Marshal.GetLastWin32Error());
-           }
-        }
-
-        /// <summary>
-        /// Computes the final hash and returns the result
-        /// </summary>
-        /// <returns>The final messge digest.</returns>
-        protected override byte[] HashFinal()
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            var res = new byte[m_size];
-            var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-
-            return res;
-        }
-
-        /// <summary>
-        /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
-        /// </summary>
-        ~OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA256()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Dispose the this instance.
-        /// </summary>
-        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (m_context != IntPtr.Zero)
-            {
-                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
-                m_context = IntPtr.Zero;
-            }
-
-            base.Dispose(disposing);
-        }
-    }
-
-
-    /// <summary>
-    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
-    /// </summary>
-    public class OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA256 : SHA256
-    {
-
-        /// <summary>
-        /// The message digest context
-        /// </summary>
-        private IntPtr m_context;
-
-        /// <summary>
-        /// The size of the message digest
-        /// </summary>
-        private readonly int m_size;
-        /// <summary>
-        /// The message digest method
-        /// </summary>
-        private readonly IntPtr m_digestmethod;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
-        /// </summary>
-        public OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA256()
-        {
-           var algorithm = "SHA256";
-            m_digestmethod = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
-            if (m_digestmethod == IntPtr.Zero)
-                throw new ArgumentException($"No such algorithm: {algorithm}");
-
-            m_size = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
-        }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int OutputBlockSize { get { return m_size; } }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
-
-        /// <summary>
-        /// Initializes the hashing algorithm
-        /// </summary>
-        public override void Initialize()
-        {
-            if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_new();
-
-            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-        }
-
-        /// <summary>
-        /// Performs the core hashing
-        /// </summary>
-        /// <param name="array">The data to hash.</param>
-        /// <param name="ibStart">The index into the array where hashing starts.</param>
-        /// <param name="cbSize">The number of bytes to hash.</param>
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            // Common case is to use offset=0, and here we can rely on the system marshaller to work
-            if (ibStart == 0)
-            {
-                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#if AVOID_PINNING_SMALL_ARRAYS
-            // For small chunks, we can copy and get mostly the same performance as the managed version
-            else if (cbSize < 1024)
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-
-                var tmp = new byte[cbSize];
-                Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#endif
-            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
-            else
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
-                pa.Free();
-                if (res != 1)
-                   throw new Win32Exception(Marshal.GetLastWin32Error());
-           }
-        }
-
-        /// <summary>
-        /// Computes the final hash and returns the result
-        /// </summary>
-        /// <returns>The final messge digest.</returns>
-        protected override byte[] HashFinal()
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            var res = new byte[m_size];
-            var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-
-            return res;
-        }
-
-        /// <summary>
-        /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
-        /// </summary>
-        ~OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA256()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Dispose the this instance.
-        /// </summary>
-        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (m_context != IntPtr.Zero)
-            {
-                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
-                m_context = IntPtr.Zero;
-            }
-
-            base.Dispose(disposing);
-        }
-    }
-
-
-    /// <summary>
-    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
-    /// </summary>
-    public class OpenSSL30_libssl_HashAlgorithmSHA384 : SHA384
-    {
-
-        /// <summary>
-        /// The message digest context
-        /// </summary>
-        private IntPtr m_context;
-
-        /// <summary>
-        /// The size of the message digest
-        /// </summary>
-        private readonly int m_size;
-        /// <summary>
-        /// The message digest method
-        /// </summary>
-        private readonly IntPtr m_digestmethod;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
-        /// </summary>
-        public OpenSSL30_libssl_HashAlgorithmSHA384()
+        public OpenSSL3_libssl_HashAlgorithmSHA384()
         {
            var algorithm = "SHA384";
-            m_digestmethod = InteropOpenSSL30_libssl.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libssl.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -14620,7 +13440,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libssl.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -14628,10 +13448,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl.EVP_MD_CTX_new();
+                InteropOpenSSL3_libssl.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libssl.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -14649,7 +13469,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -14661,7 +13481,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -14671,7 +13491,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -14689,7 +13509,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -14697,9 +13517,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA384"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_HashAlgorithmSHA384()
+        ~OpenSSL3_libssl_HashAlgorithmSHA384()
         {
             Dispose(false);
         }
@@ -14712,7 +13532,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libssl.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -14722,9 +13542,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_so_3_HashAlgorithmSHA384 : SHA384
+    public class OpenSSL3_libssl_so_3_HashAlgorithmSHA384 : SHA384
     {
 
         /// <summary>
@@ -14742,16 +13562,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA384"/> class.
         /// </summary>
-        public OpenSSL30_libssl_so_3_HashAlgorithmSHA384()
+        public OpenSSL3_libssl_so_3_HashAlgorithmSHA384()
         {
            var algorithm = "SHA384";
-            m_digestmethod = InteropOpenSSL30_libssl_so_3.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libssl_so_3.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_so_3.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libssl_so_3.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -14762,7 +13582,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -14770,10 +13590,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_new();
+                InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -14791,7 +13611,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -14803,7 +13623,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -14813,7 +13633,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -14831,7 +13651,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -14839,9 +13659,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA384"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_so_3_HashAlgorithmSHA384()
+        ~OpenSSL3_libssl_so_3_HashAlgorithmSHA384()
         {
             Dispose(false);
         }
@@ -14854,7 +13674,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -14864,9 +13684,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_so_HashAlgorithmSHA384 : SHA384
+    public class OpenSSL3_libcrypto_so_HashAlgorithmSHA384 : SHA384
     {
 
         /// <summary>
@@ -14884,16 +13704,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA384"/> class.
         /// </summary>
-        public OpenSSL30_libcrypto_so_HashAlgorithmSHA384()
+        public OpenSSL3_libcrypto_so_HashAlgorithmSHA384()
         {
            var algorithm = "SHA384";
-            m_digestmethod = InteropOpenSSL30_libcrypto_so.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_so.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libcrypto_so.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_so.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -14904,7 +13724,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -14912,10 +13732,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -14933,7 +13753,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -14945,7 +13765,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -14955,7 +13775,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -14973,7 +13793,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -14981,9 +13801,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA384"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libcrypto_so_HashAlgorithmSHA384()
+        ~OpenSSL3_libcrypto_so_HashAlgorithmSHA384()
         {
             Dispose(false);
         }
@@ -14996,7 +13816,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -15006,9 +13826,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_so_3_HashAlgorithmSHA384 : SHA384
+    public class OpenSSL3_libcrypto_so_3_HashAlgorithmSHA384 : SHA384
     {
 
         /// <summary>
@@ -15026,16 +13846,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA384"/> class.
         /// </summary>
-        public OpenSSL30_libcrypto_so_3_HashAlgorithmSHA384()
+        public OpenSSL3_libcrypto_so_3_HashAlgorithmSHA384()
         {
            var algorithm = "SHA384";
-            m_digestmethod = InteropOpenSSL30_libcrypto_so_3.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_so_3.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libcrypto_so_3.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_so_3.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -15046,7 +13866,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -15054,10 +13874,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -15075,7 +13895,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -15087,7 +13907,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -15097,7 +13917,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -15115,7 +13935,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -15123,9 +13943,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA384"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libcrypto_so_3_HashAlgorithmSHA384()
+        ~OpenSSL3_libcrypto_so_3_HashAlgorithmSHA384()
         {
             Dispose(false);
         }
@@ -15138,7 +13958,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -15148,9 +13968,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_3_dll_HashAlgorithmSHA384 : SHA384
+    public class OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA384 : SHA384
     {
 
         /// <summary>
@@ -15168,16 +13988,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA384"/> class.
         /// </summary>
-        public OpenSSL30_libssl_3_dll_HashAlgorithmSHA384()
+        public OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA384()
         {
            var algorithm = "SHA384";
-            m_digestmethod = InteropOpenSSL30_libssl_3_dll.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_3_dll.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -15188,7 +14008,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_dll.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -15196,10 +14016,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -15217,7 +14037,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -15229,7 +14049,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -15239,7 +14059,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -15257,7 +14077,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -15265,9 +14085,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA384"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_3_dll_HashAlgorithmSHA384()
+        ~OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA384()
         {
             Dispose(false);
         }
@@ -15280,7 +14100,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -15290,9 +14110,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA384 : SHA384
+    public class OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA384 : SHA384
     {
 
         /// <summary>
@@ -15310,16 +14130,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA384"/> class.
         /// </summary>
-        public OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA384()
+        public OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA384()
         {
            var algorithm = "SHA384";
-            m_digestmethod = InteropOpenSSL30_libssl_3_x64_dll.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -15330,7 +14150,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -15338,10 +14158,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -15359,7 +14179,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -15371,7 +14191,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -15381,7 +14201,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -15399,7 +14219,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -15407,9 +14227,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA384"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA384()
+        ~OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA384()
         {
             Dispose(false);
         }
@@ -15422,7 +14242,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -15432,9 +14252,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA384 : SHA384
+    public class OpenSSL3_libssl_HashAlgorithmSHA512 : SHA512
     {
 
         /// <summary>
@@ -15452,300 +14272,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA512"/> class.
         /// </summary>
-        public OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA384()
-        {
-           var algorithm = "SHA384";
-            m_digestmethod = InteropOpenSSL30_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
-            if (m_digestmethod == IntPtr.Zero)
-                throw new ArgumentException($"No such algorithm: {algorithm}");
-
-            m_size = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
-        }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int OutputBlockSize { get { return m_size; } }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
-
-        /// <summary>
-        /// Initializes the hashing algorithm
-        /// </summary>
-        public override void Initialize()
-        {
-            if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_new();
-
-            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-        }
-
-        /// <summary>
-        /// Performs the core hashing
-        /// </summary>
-        /// <param name="array">The data to hash.</param>
-        /// <param name="ibStart">The index into the array where hashing starts.</param>
-        /// <param name="cbSize">The number of bytes to hash.</param>
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            // Common case is to use offset=0, and here we can rely on the system marshaller to work
-            if (ibStart == 0)
-            {
-                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#if AVOID_PINNING_SMALL_ARRAYS
-            // For small chunks, we can copy and get mostly the same performance as the managed version
-            else if (cbSize < 1024)
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-
-                var tmp = new byte[cbSize];
-                Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#endif
-            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
-            else
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
-                pa.Free();
-                if (res != 1)
-                   throw new Win32Exception(Marshal.GetLastWin32Error());
-           }
-        }
-
-        /// <summary>
-        /// Computes the final hash and returns the result
-        /// </summary>
-        /// <returns>The final messge digest.</returns>
-        protected override byte[] HashFinal()
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            var res = new byte[m_size];
-            var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-
-            return res;
-        }
-
-        /// <summary>
-        /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
-        /// </summary>
-        ~OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA384()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Dispose the this instance.
-        /// </summary>
-        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (m_context != IntPtr.Zero)
-            {
-                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
-                m_context = IntPtr.Zero;
-            }
-
-            base.Dispose(disposing);
-        }
-    }
-
-
-    /// <summary>
-    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
-    /// </summary>
-    public class OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA384 : SHA384
-    {
-
-        /// <summary>
-        /// The message digest context
-        /// </summary>
-        private IntPtr m_context;
-
-        /// <summary>
-        /// The size of the message digest
-        /// </summary>
-        private readonly int m_size;
-        /// <summary>
-        /// The message digest method
-        /// </summary>
-        private readonly IntPtr m_digestmethod;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
-        /// </summary>
-        public OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA384()
-        {
-           var algorithm = "SHA384";
-            m_digestmethod = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
-            if (m_digestmethod == IntPtr.Zero)
-                throw new ArgumentException($"No such algorithm: {algorithm}");
-
-            m_size = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
-        }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int OutputBlockSize { get { return m_size; } }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
-
-        /// <summary>
-        /// Initializes the hashing algorithm
-        /// </summary>
-        public override void Initialize()
-        {
-            if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_new();
-
-            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-        }
-
-        /// <summary>
-        /// Performs the core hashing
-        /// </summary>
-        /// <param name="array">The data to hash.</param>
-        /// <param name="ibStart">The index into the array where hashing starts.</param>
-        /// <param name="cbSize">The number of bytes to hash.</param>
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            // Common case is to use offset=0, and here we can rely on the system marshaller to work
-            if (ibStart == 0)
-            {
-                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#if AVOID_PINNING_SMALL_ARRAYS
-            // For small chunks, we can copy and get mostly the same performance as the managed version
-            else if (cbSize < 1024)
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-
-                var tmp = new byte[cbSize];
-                Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#endif
-            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
-            else
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
-                pa.Free();
-                if (res != 1)
-                   throw new Win32Exception(Marshal.GetLastWin32Error());
-           }
-        }
-
-        /// <summary>
-        /// Computes the final hash and returns the result
-        /// </summary>
-        /// <returns>The final messge digest.</returns>
-        protected override byte[] HashFinal()
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            var res = new byte[m_size];
-            var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-
-            return res;
-        }
-
-        /// <summary>
-        /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
-        /// </summary>
-        ~OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA384()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Dispose the this instance.
-        /// </summary>
-        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (m_context != IntPtr.Zero)
-            {
-                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
-                m_context = IntPtr.Zero;
-            }
-
-            base.Dispose(disposing);
-        }
-    }
-
-
-    /// <summary>
-    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
-    /// </summary>
-    public class OpenSSL30_libssl_HashAlgorithmSHA512 : SHA512
-    {
-
-        /// <summary>
-        /// The message digest context
-        /// </summary>
-        private IntPtr m_context;
-
-        /// <summary>
-        /// The size of the message digest
-        /// </summary>
-        private readonly int m_size;
-        /// <summary>
-        /// The message digest method
-        /// </summary>
-        private readonly IntPtr m_digestmethod;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
-        /// </summary>
-        public OpenSSL30_libssl_HashAlgorithmSHA512()
+        public OpenSSL3_libssl_HashAlgorithmSHA512()
         {
            var algorithm = "SHA512";
-            m_digestmethod = InteropOpenSSL30_libssl.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libssl.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -15756,7 +14292,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libssl.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -15764,10 +14300,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl.EVP_MD_CTX_new();
+                InteropOpenSSL3_libssl.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libssl.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -15785,7 +14321,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -15797,7 +14333,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -15807,7 +14343,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -15825,7 +14361,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -15833,9 +14369,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA512"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_HashAlgorithmSHA512()
+        ~OpenSSL3_libssl_HashAlgorithmSHA512()
         {
             Dispose(false);
         }
@@ -15848,7 +14384,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libssl.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -15858,9 +14394,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_so_3_HashAlgorithmSHA512 : SHA512
+    public class OpenSSL3_libssl_so_3_HashAlgorithmSHA512 : SHA512
     {
 
         /// <summary>
@@ -15878,16 +14414,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA512"/> class.
         /// </summary>
-        public OpenSSL30_libssl_so_3_HashAlgorithmSHA512()
+        public OpenSSL3_libssl_so_3_HashAlgorithmSHA512()
         {
            var algorithm = "SHA512";
-            m_digestmethod = InteropOpenSSL30_libssl_so_3.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libssl_so_3.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_so_3.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libssl_so_3.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -15898,7 +14434,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -15906,10 +14442,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_new();
+                InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -15927,7 +14463,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -15939,7 +14475,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -15949,7 +14485,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -15967,7 +14503,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -15975,9 +14511,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA512"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_so_3_HashAlgorithmSHA512()
+        ~OpenSSL3_libssl_so_3_HashAlgorithmSHA512()
         {
             Dispose(false);
         }
@@ -15990,7 +14526,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libssl_so_3.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -16000,9 +14536,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_so_HashAlgorithmSHA512 : SHA512
+    public class OpenSSL3_libcrypto_so_HashAlgorithmSHA512 : SHA512
     {
 
         /// <summary>
@@ -16020,16 +14556,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA512"/> class.
         /// </summary>
-        public OpenSSL30_libcrypto_so_HashAlgorithmSHA512()
+        public OpenSSL3_libcrypto_so_HashAlgorithmSHA512()
         {
            var algorithm = "SHA512";
-            m_digestmethod = InteropOpenSSL30_libcrypto_so.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_so.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libcrypto_so.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_so.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -16040,7 +14576,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -16048,10 +14584,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -16069,7 +14605,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -16081,7 +14617,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -16091,7 +14627,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -16109,7 +14645,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -16117,9 +14653,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA512"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libcrypto_so_HashAlgorithmSHA512()
+        ~OpenSSL3_libcrypto_so_HashAlgorithmSHA512()
         {
             Dispose(false);
         }
@@ -16132,7 +14668,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_so.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -16142,9 +14678,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libcrypto_so_3_HashAlgorithmSHA512 : SHA512
+    public class OpenSSL3_libcrypto_so_3_HashAlgorithmSHA512 : SHA512
     {
 
         /// <summary>
@@ -16162,16 +14698,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA512"/> class.
         /// </summary>
-        public OpenSSL30_libcrypto_so_3_HashAlgorithmSHA512()
+        public OpenSSL3_libcrypto_so_3_HashAlgorithmSHA512()
         {
            var algorithm = "SHA512";
-            m_digestmethod = InteropOpenSSL30_libcrypto_so_3.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_so_3.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libcrypto_so_3.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_so_3.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -16182,7 +14718,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -16190,10 +14726,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -16211,7 +14747,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -16223,7 +14759,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -16233,7 +14769,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -16251,7 +14787,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -16259,9 +14795,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA512"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libcrypto_so_3_HashAlgorithmSHA512()
+        ~OpenSSL3_libcrypto_so_3_HashAlgorithmSHA512()
         {
             Dispose(false);
         }
@@ -16274,7 +14810,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_so_3.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -16284,9 +14820,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_3_dll_HashAlgorithmSHA512 : SHA512
+    public class OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA512 : SHA512
     {
 
         /// <summary>
@@ -16304,16 +14840,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA512"/> class.
         /// </summary>
-        public OpenSSL30_libssl_3_dll_HashAlgorithmSHA512()
+        public OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA512()
         {
            var algorithm = "SHA512";
-            m_digestmethod = InteropOpenSSL30_libssl_3_dll.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_3_dll.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -16324,7 +14860,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_dll.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -16332,10 +14868,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -16353,7 +14889,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -16365,7 +14901,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -16375,7 +14911,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -16393,7 +14929,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -16401,9 +14937,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA512"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_3_dll_HashAlgorithmSHA512()
+        ~OpenSSL3_libcrypto_3_dll_HashAlgorithmSHA512()
         {
             Dispose(false);
         }
@@ -16416,7 +14952,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 
@@ -16426,9 +14962,9 @@ namespace FasterHashing
 
 
     /// <summary>
-    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
+    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3
     /// </summary>
-    public class OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA512 : SHA512
+    public class OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA512 : SHA512
     {
 
         /// <summary>
@@ -16446,16 +14982,16 @@ namespace FasterHashing
         private readonly IntPtr m_digestmethod;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA512"/> class.
         /// </summary>
-        public OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA512()
+        public OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA512()
         {
            var algorithm = "SHA512";
-            m_digestmethod = InteropOpenSSL30_libssl_3_x64_dll.EVP_get_digestbyname(algorithm);
+            m_digestmethod = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
 
-            m_size = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_size(m_digestmethod);
+            m_size = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
         }
 
         /// <summary>
@@ -16466,7 +15002,7 @@ namespace FasterHashing
         /// <summary>
         /// Gets the size of the message digest in bytes
         /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+        public override int InputBlockSize { get { return InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
 
         /// <summary>
         /// Initializes the hashing algorithm
@@ -16474,10 +15010,10 @@ namespace FasterHashing
         public override void Initialize()
         {
             if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_new();
+                InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_new();
 
-            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+            if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
         }
 
@@ -16495,7 +15031,7 @@ namespace FasterHashing
             // Common case is to use offset=0, and here we can rely on the system marshaller to work
             if (ibStart == 0)
             {
-                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #if AVOID_PINNING_SMALL_ARRAYS
@@ -16507,7 +15043,7 @@ namespace FasterHashing
 
                 var tmp = new byte[cbSize];
                 Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
                     throw new Win32Exception(Marshal.GetLastWin32Error());
             }
 #endif
@@ -16517,7 +15053,7 @@ namespace FasterHashing
                 System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
                 ErrorStateHelper.HasReportedOffsetIssue = true;
                 var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                var res = InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
                 pa.Free();
                 if (res != 1)
                    throw new Win32Exception(Marshal.GetLastWin32Error());
@@ -16535,7 +15071,7 @@ namespace FasterHashing
 
             var res = new byte[m_size];
             var rs = (uint)m_size;
-            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+            if (InteropOpenSSL3_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
                 throw new Win32Exception(Marshal.GetLastWin32Error());
 
             return res;
@@ -16543,9 +15079,9 @@ namespace FasterHashing
 
         /// <summary>
         /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
+        /// <see cref="T:FasterHashing.OpenSSL3HashAlgorithmSHA512"/> is reclaimed by garbage collection.
         /// </summary>
-        ~OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA512()
+        ~OpenSSL3_libcrypto_3_x64_dll_HashAlgorithmSHA512()
         {
             Dispose(false);
         }
@@ -16558,291 +15094,7 @@ namespace FasterHashing
         {
             if (m_context != IntPtr.Zero)
             {
-                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
-                m_context = IntPtr.Zero;
-            }
-
-            base.Dispose(disposing);
-        }
-    }
-
-
-    /// <summary>
-    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
-    /// </summary>
-    public class OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA512 : SHA512
-    {
-
-        /// <summary>
-        /// The message digest context
-        /// </summary>
-        private IntPtr m_context;
-
-        /// <summary>
-        /// The size of the message digest
-        /// </summary>
-        private readonly int m_size;
-        /// <summary>
-        /// The message digest method
-        /// </summary>
-        private readonly IntPtr m_digestmethod;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
-        /// </summary>
-        public OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA512()
-        {
-           var algorithm = "SHA512";
-            m_digestmethod = InteropOpenSSL30_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
-            if (m_digestmethod == IntPtr.Zero)
-                throw new ArgumentException($"No such algorithm: {algorithm}");
-
-            m_size = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
-        }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int OutputBlockSize { get { return m_size; } }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
-
-        /// <summary>
-        /// Initializes the hashing algorithm
-        /// </summary>
-        public override void Initialize()
-        {
-            if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_new();
-
-            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-        }
-
-        /// <summary>
-        /// Performs the core hashing
-        /// </summary>
-        /// <param name="array">The data to hash.</param>
-        /// <param name="ibStart">The index into the array where hashing starts.</param>
-        /// <param name="cbSize">The number of bytes to hash.</param>
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            // Common case is to use offset=0, and here we can rely on the system marshaller to work
-            if (ibStart == 0)
-            {
-                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#if AVOID_PINNING_SMALL_ARRAYS
-            // For small chunks, we can copy and get mostly the same performance as the managed version
-            else if (cbSize < 1024)
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-
-                var tmp = new byte[cbSize];
-                Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#endif
-            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
-            else
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
-                pa.Free();
-                if (res != 1)
-                   throw new Win32Exception(Marshal.GetLastWin32Error());
-           }
-        }
-
-        /// <summary>
-        /// Computes the final hash and returns the result
-        /// </summary>
-        /// <returns>The final messge digest.</returns>
-        protected override byte[] HashFinal()
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            var res = new byte[m_size];
-            var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-
-            return res;
-        }
-
-        /// <summary>
-        /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
-        /// </summary>
-        ~OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA512()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Dispose the this instance.
-        /// </summary>
-        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (m_context != IntPtr.Zero)
-            {
-                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
-                m_context = IntPtr.Zero;
-            }
-
-            base.Dispose(disposing);
-        }
-    }
-
-
-    /// <summary>
-    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
-    /// </summary>
-    public class OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA512 : SHA512
-    {
-
-        /// <summary>
-        /// The message digest context
-        /// </summary>
-        private IntPtr m_context;
-
-        /// <summary>
-        /// The size of the message digest
-        /// </summary>
-        private readonly int m_size;
-        /// <summary>
-        /// The message digest method
-        /// </summary>
-        private readonly IntPtr m_digestmethod;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
-        /// </summary>
-        public OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA512()
-        {
-           var algorithm = "SHA512";
-            m_digestmethod = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
-            if (m_digestmethod == IntPtr.Zero)
-                throw new ArgumentException($"No such algorithm: {algorithm}");
-
-            m_size = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
-        }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int OutputBlockSize { get { return m_size; } }
-
-        /// <summary>
-        /// Gets the size of the message digest in bytes
-        /// </summary>
-        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
-
-        /// <summary>
-        /// Initializes the hashing algorithm
-        /// </summary>
-        public override void Initialize()
-        {
-            if (m_context != IntPtr.Zero)
-                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
-            m_context = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_new();
-
-            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-        }
-
-        /// <summary>
-        /// Performs the core hashing
-        /// </summary>
-        /// <param name="array">The data to hash.</param>
-        /// <param name="ibStart">The index into the array where hashing starts.</param>
-        /// <param name="cbSize">The number of bytes to hash.</param>
-        protected override void HashCore(byte[] array, int ibStart, int cbSize)
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            // Common case is to use offset=0, and here we can rely on the system marshaller to work
-            if (ibStart == 0)
-            {
-                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#if AVOID_PINNING_SMALL_ARRAYS
-            // For small chunks, we can copy and get mostly the same performance as the managed version
-            else if (cbSize < 1024)
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-
-                var tmp = new byte[cbSize];
-                Array.Copy(array, ibStart, tmp, 0, cbSize);
-                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
-                    throw new Win32Exception(Marshal.GetLastWin32Error());
-            }
-#endif
-            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
-            else
-            {
-                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
-                ErrorStateHelper.HasReportedOffsetIssue = true;
-                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
-                var res = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
-                pa.Free();
-                if (res != 1)
-                   throw new Win32Exception(Marshal.GetLastWin32Error());
-           }
-        }
-
-        /// <summary>
-        /// Computes the final hash and returns the result
-        /// </summary>
-        /// <returns>The final messge digest.</returns>
-        protected override byte[] HashFinal()
-        {
-            if (m_context == IntPtr.Zero)
-                Initialize();
-
-            var res = new byte[m_size];
-            var rs = (uint)m_size;
-            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
-                throw new Win32Exception(Marshal.GetLastWin32Error());
-
-            return res;
-        }
-
-        /// <summary>
-        /// Releases unmanaged resources and performs other cleanup operations before the
-        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
-        /// </summary>
-        ~OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA512()
-        {
-            Dispose(false);
-        }
-
-        /// <summary>
-        /// Dispose the this instance.
-        /// </summary>
-        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
-        protected override void Dispose(bool disposing)
-        {
-            if (m_context != IntPtr.Zero)
-            {
-                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+                InteropOpenSSL3_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
                 m_context = IntPtr.Zero;
             }
 

--- a/FasterHashing/OpenSSLImplementations.cs
+++ b/FasterHashing/OpenSSLImplementations.cs
@@ -1,27 +1,19 @@
-﻿
-
-
-
-
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
 namespace FasterHashing
 {
-
     /// <summary>
     /// Implementation of a hash algorithm, using OpenSSL 1.0
     /// </summary>
     public class OpenSSL10_libssl_HashAlgorithm : HashAlgorithm
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -40,19 +32,14 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithm"/> class.
         /// </summary>
-
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-
         public OpenSSL10_libssl_HashAlgorithm(string algorithm)
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl.OpenSSL_add_all_digests();
                 _first = false;
             }
-
-
 
             m_digestmethod = InteropOpenSSL10_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
@@ -168,37 +155,28 @@ namespace FasterHashing
             base.Dispose(disposing);
         }
 
-
         /// <summary>
         /// Creates a new hash algorithm using an OpenSSL10 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
-
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_HashAlgorithmMD5();
-
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_HashAlgorithmSHA1();
-
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_HashAlgorithmSHA256();
-
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_HashAlgorithmSHA384();
-
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_HashAlgorithmSHA512();
-
             try { return new OpenSSL10_libssl_HashAlgorithm(name); }
             catch { }
 
             return null;
         }
-
     }
-
 
 
     /// <summary>
@@ -206,12 +184,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_so_1_0_HashAlgorithm : HashAlgorithm
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -230,19 +206,14 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithm"/> class.
         /// </summary>
-
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-
         public OpenSSL10_libssl_so_1_0_HashAlgorithm(string algorithm)
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl_so_1_0.OpenSSL_add_all_digests();
                 _first = false;
             }
-
-
 
             m_digestmethod = InteropOpenSSL10_libssl_so_1_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
@@ -358,37 +329,28 @@ namespace FasterHashing
             base.Dispose(disposing);
         }
 
-
         /// <summary>
         /// Creates a new hash algorithm using an OpenSSL10 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
-
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_so_1_0_HashAlgorithmMD5();
-
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_so_1_0_HashAlgorithmSHA1();
-
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_so_1_0_HashAlgorithmSHA256();
-
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_so_1_0_HashAlgorithmSHA384();
-
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_so_1_0_HashAlgorithmSHA512();
-
             try { return new OpenSSL10_libssl_so_1_0_HashAlgorithm(name); }
             catch { }
 
             return null;
         }
-
     }
-
 
 
     /// <summary>
@@ -396,12 +358,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_so_1_0_0_HashAlgorithm : HashAlgorithm
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -420,19 +380,14 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithm"/> class.
         /// </summary>
-
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-
         public OpenSSL10_libssl_so_1_0_0_HashAlgorithm(string algorithm)
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl_so_1_0_0.OpenSSL_add_all_digests();
                 _first = false;
             }
-
-
 
             m_digestmethod = InteropOpenSSL10_libssl_so_1_0_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
@@ -548,37 +503,28 @@ namespace FasterHashing
             base.Dispose(disposing);
         }
 
-
         /// <summary>
         /// Creates a new hash algorithm using an OpenSSL10 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
-
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_so_1_0_0_HashAlgorithmMD5();
-
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_so_1_0_0_HashAlgorithmSHA1();
-
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_so_1_0_0_HashAlgorithmSHA256();
-
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_so_1_0_0_HashAlgorithmSHA384();
-
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libssl_so_1_0_0_HashAlgorithmSHA512();
-
             try { return new OpenSSL10_libssl_so_1_0_0_HashAlgorithm(name); }
             catch { }
 
             return null;
         }
-
     }
-
 
 
     /// <summary>
@@ -586,12 +532,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libeay32_dll_HashAlgorithm : HashAlgorithm
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -610,19 +554,14 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithm"/> class.
         /// </summary>
-
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-
         public OpenSSL10_libeay32_dll_HashAlgorithm(string algorithm)
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libeay32_dll.OpenSSL_add_all_digests();
                 _first = false;
             }
-
-
 
             m_digestmethod = InteropOpenSSL10_libeay32_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
@@ -738,38 +677,28 @@ namespace FasterHashing
             base.Dispose(disposing);
         }
 
-
         /// <summary>
         /// Creates a new hash algorithm using an OpenSSL10 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
-
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libeay32_dll_HashAlgorithmMD5();
-
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libeay32_dll_HashAlgorithmSHA1();
-
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libeay32_dll_HashAlgorithmSHA256();
-
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libeay32_dll_HashAlgorithmSHA384();
-
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL10_libeay32_dll_HashAlgorithmSHA512();
-
             try { return new OpenSSL10_libeay32_dll_HashAlgorithm(name); }
             catch { }
 
             return null;
         }
-
     }
-
-
 
 
     /// <summary>
@@ -777,12 +706,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_HashAlgorithmMD5 : MD5
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -801,20 +728,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmMD5"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_HashAlgorithmMD5()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "MD5";
-
             m_digestmethod = InteropOpenSSL10_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -928,9 +850,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -938,12 +858,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_so_1_0_HashAlgorithmMD5 : MD5
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -962,20 +880,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmMD5"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_so_1_0_HashAlgorithmMD5()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl_so_1_0.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "MD5";
-
             m_digestmethod = InteropOpenSSL10_libssl_so_1_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -1089,9 +1002,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -1099,12 +1010,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_so_1_0_0_HashAlgorithmMD5 : MD5
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -1123,20 +1032,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmMD5"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_so_1_0_0_HashAlgorithmMD5()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl_so_1_0_0.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "MD5";
-
             m_digestmethod = InteropOpenSSL10_libssl_so_1_0_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -1250,9 +1154,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -1260,12 +1162,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libeay32_dll_HashAlgorithmMD5 : MD5
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -1284,20 +1184,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmMD5"/> class.
         /// </summary>
-
         public OpenSSL10_libeay32_dll_HashAlgorithmMD5()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libeay32_dll.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "MD5";
-
             m_digestmethod = InteropOpenSSL10_libeay32_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -1411,10 +1306,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
-
 
 
     /// <summary>
@@ -1422,12 +1314,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_HashAlgorithmSHA1 : SHA1
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -1446,20 +1336,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA1"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_HashAlgorithmSHA1()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA1";
-
             m_digestmethod = InteropOpenSSL10_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -1573,9 +1458,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -1583,12 +1466,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_so_1_0_HashAlgorithmSHA1 : SHA1
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -1607,20 +1488,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA1"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_so_1_0_HashAlgorithmSHA1()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl_so_1_0.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA1";
-
             m_digestmethod = InteropOpenSSL10_libssl_so_1_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -1734,9 +1610,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -1744,12 +1618,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_so_1_0_0_HashAlgorithmSHA1 : SHA1
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -1768,20 +1640,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA1"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_so_1_0_0_HashAlgorithmSHA1()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl_so_1_0_0.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA1";
-
             m_digestmethod = InteropOpenSSL10_libssl_so_1_0_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -1895,9 +1762,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -1905,12 +1770,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libeay32_dll_HashAlgorithmSHA1 : SHA1
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -1929,20 +1792,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA1"/> class.
         /// </summary>
-
         public OpenSSL10_libeay32_dll_HashAlgorithmSHA1()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libeay32_dll.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA1";
-
             m_digestmethod = InteropOpenSSL10_libeay32_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -2056,10 +1914,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
-
 
 
     /// <summary>
@@ -2067,12 +1922,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_HashAlgorithmSHA256 : SHA256
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -2091,20 +1944,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA256"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_HashAlgorithmSHA256()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA256";
-
             m_digestmethod = InteropOpenSSL10_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -2218,9 +2066,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -2228,12 +2074,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_so_1_0_HashAlgorithmSHA256 : SHA256
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -2252,20 +2096,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA256"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_so_1_0_HashAlgorithmSHA256()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl_so_1_0.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA256";
-
             m_digestmethod = InteropOpenSSL10_libssl_so_1_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -2379,9 +2218,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -2389,12 +2226,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_so_1_0_0_HashAlgorithmSHA256 : SHA256
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -2413,20 +2248,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA256"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_so_1_0_0_HashAlgorithmSHA256()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl_so_1_0_0.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA256";
-
             m_digestmethod = InteropOpenSSL10_libssl_so_1_0_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -2540,9 +2370,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -2550,12 +2378,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libeay32_dll_HashAlgorithmSHA256 : SHA256
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -2574,20 +2400,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA256"/> class.
         /// </summary>
-
         public OpenSSL10_libeay32_dll_HashAlgorithmSHA256()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libeay32_dll.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA256";
-
             m_digestmethod = InteropOpenSSL10_libeay32_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -2701,10 +2522,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
-
 
 
     /// <summary>
@@ -2712,12 +2530,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_HashAlgorithmSHA384 : SHA384
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -2736,20 +2552,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA384"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_HashAlgorithmSHA384()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA384";
-
             m_digestmethod = InteropOpenSSL10_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -2863,9 +2674,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -2873,12 +2682,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_so_1_0_HashAlgorithmSHA384 : SHA384
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -2897,20 +2704,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA384"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_so_1_0_HashAlgorithmSHA384()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl_so_1_0.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA384";
-
             m_digestmethod = InteropOpenSSL10_libssl_so_1_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -3024,9 +2826,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -3034,12 +2834,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_so_1_0_0_HashAlgorithmSHA384 : SHA384
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -3058,20 +2856,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA384"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_so_1_0_0_HashAlgorithmSHA384()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl_so_1_0_0.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA384";
-
             m_digestmethod = InteropOpenSSL10_libssl_so_1_0_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -3185,9 +2978,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -3195,12 +2986,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libeay32_dll_HashAlgorithmSHA384 : SHA384
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -3219,20 +3008,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA384"/> class.
         /// </summary>
-
         public OpenSSL10_libeay32_dll_HashAlgorithmSHA384()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libeay32_dll.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA384";
-
             m_digestmethod = InteropOpenSSL10_libeay32_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -3346,10 +3130,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
-
 
 
     /// <summary>
@@ -3357,12 +3138,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_HashAlgorithmSHA512 : SHA512
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -3381,20 +3160,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA512"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_HashAlgorithmSHA512()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA512";
-
             m_digestmethod = InteropOpenSSL10_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -3508,9 +3282,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -3518,12 +3290,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_so_1_0_HashAlgorithmSHA512 : SHA512
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -3542,20 +3312,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA512"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_so_1_0_HashAlgorithmSHA512()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl_so_1_0.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA512";
-
             m_digestmethod = InteropOpenSSL10_libssl_so_1_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -3669,9 +3434,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -3679,12 +3442,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libssl_so_1_0_0_HashAlgorithmSHA512 : SHA512
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -3703,20 +3464,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA512"/> class.
         /// </summary>
-
         public OpenSSL10_libssl_so_1_0_0_HashAlgorithmSHA512()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libssl_so_1_0_0.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA512";
-
             m_digestmethod = InteropOpenSSL10_libssl_so_1_0_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -3830,9 +3586,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -3840,12 +3594,10 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL10_libeay32_dll_HashAlgorithmSHA512 : SHA512
     {
-
         /// <summary>
         /// Flag to toggle calling &quot;OpenSSL_add_all_digests()&quot;
         /// </summary>
         public static bool _first = true;
-
 
         /// <summary>
         /// The message digest context
@@ -3864,20 +3616,15 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL10HashAlgorithmSHA512"/> class.
         /// </summary>
-
         public OpenSSL10_libeay32_dll_HashAlgorithmSHA512()
         {
-
             if (_first)
             {
                 InteropOpenSSL10_libeay32_dll.OpenSSL_add_all_digests();
                 _first = false;
             }
 
-
-
            var algorithm = "SHA512";
-
             m_digestmethod = InteropOpenSSL10_libeay32_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -3991,11 +3738,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
-
-
 
 
     /// <summary>
@@ -4003,7 +3746,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_HashAlgorithm : HashAlgorithm
     {
-
 
         /// <summary>
         /// The message digest context
@@ -4022,13 +3764,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithm"/> class.
         /// </summary>
-
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-
         public OpenSSL11_libssl_HashAlgorithm(string algorithm)
         {
-
-
             m_digestmethod = InteropOpenSSL11_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -4143,37 +3881,28 @@ namespace FasterHashing
             base.Dispose(disposing);
         }
 
-
         /// <summary>
         /// Creates a new hash algorithm using an OpenSSL11 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
-
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_HashAlgorithmMD5();
-
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_HashAlgorithmSHA1();
-
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_HashAlgorithmSHA256();
-
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_HashAlgorithmSHA384();
-
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_HashAlgorithmSHA512();
-
             try { return new OpenSSL11_libssl_HashAlgorithm(name); }
             catch { }
 
             return null;
         }
-
     }
-
 
 
     /// <summary>
@@ -4181,7 +3910,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_so_1_1_HashAlgorithm : HashAlgorithm
     {
-
 
         /// <summary>
         /// The message digest context
@@ -4200,13 +3928,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithm"/> class.
         /// </summary>
-
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-
         public OpenSSL11_libssl_so_1_1_HashAlgorithm(string algorithm)
         {
-
-
             m_digestmethod = InteropOpenSSL11_libssl_so_1_1.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -4321,37 +4045,28 @@ namespace FasterHashing
             base.Dispose(disposing);
         }
 
-
         /// <summary>
         /// Creates a new hash algorithm using an OpenSSL11 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
-
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_so_1_1_HashAlgorithmMD5();
-
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_so_1_1_HashAlgorithmSHA1();
-
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_so_1_1_HashAlgorithmSHA256();
-
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_so_1_1_HashAlgorithmSHA384();
-
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_so_1_1_HashAlgorithmSHA512();
-
             try { return new OpenSSL11_libssl_so_1_1_HashAlgorithm(name); }
             catch { }
 
             return null;
         }
-
     }
-
 
 
     /// <summary>
@@ -4359,7 +4074,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_so_1_1_0_HashAlgorithm : HashAlgorithm
     {
-
 
         /// <summary>
         /// The message digest context
@@ -4378,13 +4092,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithm"/> class.
         /// </summary>
-
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-
         public OpenSSL11_libssl_so_1_1_0_HashAlgorithm(string algorithm)
         {
-
-
             m_digestmethod = InteropOpenSSL11_libssl_so_1_1_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -4499,37 +4209,28 @@ namespace FasterHashing
             base.Dispose(disposing);
         }
 
-
         /// <summary>
         /// Creates a new hash algorithm using an OpenSSL11 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
-
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_so_1_1_0_HashAlgorithmMD5();
-
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_so_1_1_0_HashAlgorithmSHA1();
-
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_so_1_1_0_HashAlgorithmSHA256();
-
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_so_1_1_0_HashAlgorithmSHA384();
-
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libssl_so_1_1_0_HashAlgorithmSHA512();
-
             try { return new OpenSSL11_libssl_so_1_1_0_HashAlgorithm(name); }
             catch { }
 
             return null;
         }
-
     }
-
 
 
     /// <summary>
@@ -4537,7 +4238,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_dll_HashAlgorithm : HashAlgorithm
     {
-
 
         /// <summary>
         /// The message digest context
@@ -4556,13 +4256,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithm"/> class.
         /// </summary>
-
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-
         public OpenSSL11_libcrypto_dll_HashAlgorithm(string algorithm)
         {
-
-
             m_digestmethod = InteropOpenSSL11_libcrypto_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -4677,37 +4373,28 @@ namespace FasterHashing
             base.Dispose(disposing);
         }
 
-
         /// <summary>
         /// Creates a new hash algorithm using an OpenSSL11 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
-
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_dll_HashAlgorithmMD5();
-
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_dll_HashAlgorithmSHA1();
-
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_dll_HashAlgorithmSHA256();
-
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_dll_HashAlgorithmSHA384();
-
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_dll_HashAlgorithmSHA512();
-
             try { return new OpenSSL11_libcrypto_dll_HashAlgorithm(name); }
             catch { }
 
             return null;
         }
-
     }
-
 
 
     /// <summary>
@@ -4715,7 +4402,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_1_1_dll_HashAlgorithm : HashAlgorithm
     {
-
 
         /// <summary>
         /// The message digest context
@@ -4734,13 +4420,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithm"/> class.
         /// </summary>
-
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-
         public OpenSSL11_libcrypto_1_1_dll_HashAlgorithm(string algorithm)
         {
-
-
             m_digestmethod = InteropOpenSSL11_libcrypto_1_1_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -4855,37 +4537,28 @@ namespace FasterHashing
             base.Dispose(disposing);
         }
 
-
         /// <summary>
         /// Creates a new hash algorithm using an OpenSSL11 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
-
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_1_1_dll_HashAlgorithmMD5();
-
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_1_1_dll_HashAlgorithmSHA1();
-
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_1_1_dll_HashAlgorithmSHA256();
-
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_1_1_dll_HashAlgorithmSHA384();
-
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_1_1_dll_HashAlgorithmSHA512();
-
             try { return new OpenSSL11_libcrypto_1_1_dll_HashAlgorithm(name); }
             catch { }
 
             return null;
         }
-
     }
-
 
 
     /// <summary>
@@ -4893,7 +4566,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithm : HashAlgorithm
     {
-
 
         /// <summary>
         /// The message digest context
@@ -4912,13 +4584,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithm"/> class.
         /// </summary>
-
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-
         public OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithm(string algorithm)
         {
-
-
             m_digestmethod = InteropOpenSSL11_libcrypto_1_1_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -5033,37 +4701,28 @@ namespace FasterHashing
             base.Dispose(disposing);
         }
 
-
         /// <summary>
         /// Creates a new hash algorithm using an OpenSSL11 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
-
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmMD5();
-
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmSHA1();
-
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmSHA256();
-
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmSHA384();
-
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmSHA512();
-
             try { return new OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithm(name); }
             catch { }
 
             return null;
         }
-
     }
-
 
 
     /// <summary>
@@ -5071,7 +4730,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_x64_dll_HashAlgorithm : HashAlgorithm
     {
-
 
         /// <summary>
         /// The message digest context
@@ -5090,13 +4748,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithm"/> class.
         /// </summary>
-
         /// <param name="algorithm">The name of the hash algorithm to use.</param>
-
         public OpenSSL11_libcrypto_x64_dll_HashAlgorithm(string algorithm)
         {
-
-
             m_digestmethod = InteropOpenSSL11_libcrypto_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -5211,38 +4865,28 @@ namespace FasterHashing
             base.Dispose(disposing);
         }
 
-
         /// <summary>
         /// Creates a new hash algorithm using an OpenSSL11 implementation
         /// </summary>
         /// <param name-"name">The name of the algorithm to create</param>
         public static new HashAlgorithm Create(string name)
         {
-
             if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_x64_dll_HashAlgorithmMD5();
-
             if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_x64_dll_HashAlgorithmSHA1();
-
             if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_x64_dll_HashAlgorithmSHA256();
-
             if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_x64_dll_HashAlgorithmSHA384();
-
             if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
                 return new OpenSSL11_libcrypto_x64_dll_HashAlgorithmSHA512();
-
             try { return new OpenSSL11_libcrypto_x64_dll_HashAlgorithm(name); }
             catch { }
 
             return null;
         }
-
     }
-
-
 
 
     /// <summary>
@@ -5250,7 +4894,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_HashAlgorithmMD5 : MD5
     {
-
 
         /// <summary>
         /// The message digest context
@@ -5269,13 +4912,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmMD5"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_HashAlgorithmMD5()
         {
-
-
            var algorithm = "MD5";
-
             m_digestmethod = InteropOpenSSL11_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -5389,9 +5028,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -5399,7 +5036,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_so_1_1_HashAlgorithmMD5 : MD5
     {
-
 
         /// <summary>
         /// The message digest context
@@ -5418,13 +5054,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmMD5"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_so_1_1_HashAlgorithmMD5()
         {
-
-
            var algorithm = "MD5";
-
             m_digestmethod = InteropOpenSSL11_libssl_so_1_1.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -5538,9 +5170,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -5548,7 +5178,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_so_1_1_0_HashAlgorithmMD5 : MD5
     {
-
 
         /// <summary>
         /// The message digest context
@@ -5567,13 +5196,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmMD5"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_so_1_1_0_HashAlgorithmMD5()
         {
-
-
            var algorithm = "MD5";
-
             m_digestmethod = InteropOpenSSL11_libssl_so_1_1_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -5687,9 +5312,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -5697,7 +5320,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_dll_HashAlgorithmMD5 : MD5
     {
-
 
         /// <summary>
         /// The message digest context
@@ -5716,13 +5338,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmMD5"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_dll_HashAlgorithmMD5()
         {
-
-
            var algorithm = "MD5";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -5836,9 +5454,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -5846,7 +5462,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_1_1_dll_HashAlgorithmMD5 : MD5
     {
-
 
         /// <summary>
         /// The message digest context
@@ -5865,13 +5480,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmMD5"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_1_1_dll_HashAlgorithmMD5()
         {
-
-
            var algorithm = "MD5";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_1_1_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -5985,9 +5596,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -5995,7 +5604,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmMD5 : MD5
     {
-
 
         /// <summary>
         /// The message digest context
@@ -6014,13 +5622,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmMD5"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmMD5()
         {
-
-
            var algorithm = "MD5";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_1_1_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -6134,9 +5738,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -6144,7 +5746,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_x64_dll_HashAlgorithmMD5 : MD5
     {
-
 
         /// <summary>
         /// The message digest context
@@ -6163,13 +5764,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmMD5"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_x64_dll_HashAlgorithmMD5()
         {
-
-
            var algorithm = "MD5";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -6283,10 +5880,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
-
 
 
     /// <summary>
@@ -6294,7 +5888,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_HashAlgorithmSHA1 : SHA1
     {
-
 
         /// <summary>
         /// The message digest context
@@ -6313,13 +5906,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA1"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_HashAlgorithmSHA1()
         {
-
-
            var algorithm = "SHA1";
-
             m_digestmethod = InteropOpenSSL11_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -6433,9 +6022,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -6443,7 +6030,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_so_1_1_HashAlgorithmSHA1 : SHA1
     {
-
 
         /// <summary>
         /// The message digest context
@@ -6462,13 +6048,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA1"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_so_1_1_HashAlgorithmSHA1()
         {
-
-
            var algorithm = "SHA1";
-
             m_digestmethod = InteropOpenSSL11_libssl_so_1_1.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -6582,9 +6164,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -6592,7 +6172,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_so_1_1_0_HashAlgorithmSHA1 : SHA1
     {
-
 
         /// <summary>
         /// The message digest context
@@ -6611,13 +6190,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA1"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_so_1_1_0_HashAlgorithmSHA1()
         {
-
-
            var algorithm = "SHA1";
-
             m_digestmethod = InteropOpenSSL11_libssl_so_1_1_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -6731,9 +6306,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -6741,7 +6314,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_dll_HashAlgorithmSHA1 : SHA1
     {
-
 
         /// <summary>
         /// The message digest context
@@ -6760,13 +6332,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA1"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_dll_HashAlgorithmSHA1()
         {
-
-
            var algorithm = "SHA1";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -6880,9 +6448,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -6890,7 +6456,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_1_1_dll_HashAlgorithmSHA1 : SHA1
     {
-
 
         /// <summary>
         /// The message digest context
@@ -6909,13 +6474,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA1"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_1_1_dll_HashAlgorithmSHA1()
         {
-
-
            var algorithm = "SHA1";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_1_1_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -7029,9 +6590,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -7039,7 +6598,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmSHA1 : SHA1
     {
-
 
         /// <summary>
         /// The message digest context
@@ -7058,13 +6616,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA1"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmSHA1()
         {
-
-
            var algorithm = "SHA1";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_1_1_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -7178,9 +6732,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -7188,7 +6740,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_x64_dll_HashAlgorithmSHA1 : SHA1
     {
-
 
         /// <summary>
         /// The message digest context
@@ -7207,13 +6758,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA1"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_x64_dll_HashAlgorithmSHA1()
         {
-
-
            var algorithm = "SHA1";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -7327,10 +6874,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
-
 
 
     /// <summary>
@@ -7338,7 +6882,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_HashAlgorithmSHA256 : SHA256
     {
-
 
         /// <summary>
         /// The message digest context
@@ -7357,13 +6900,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA256"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_HashAlgorithmSHA256()
         {
-
-
            var algorithm = "SHA256";
-
             m_digestmethod = InteropOpenSSL11_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -7477,9 +7016,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -7487,7 +7024,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_so_1_1_HashAlgorithmSHA256 : SHA256
     {
-
 
         /// <summary>
         /// The message digest context
@@ -7506,13 +7042,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA256"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_so_1_1_HashAlgorithmSHA256()
         {
-
-
            var algorithm = "SHA256";
-
             m_digestmethod = InteropOpenSSL11_libssl_so_1_1.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -7626,9 +7158,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -7636,7 +7166,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_so_1_1_0_HashAlgorithmSHA256 : SHA256
     {
-
 
         /// <summary>
         /// The message digest context
@@ -7655,13 +7184,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA256"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_so_1_1_0_HashAlgorithmSHA256()
         {
-
-
            var algorithm = "SHA256";
-
             m_digestmethod = InteropOpenSSL11_libssl_so_1_1_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -7775,9 +7300,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -7785,7 +7308,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_dll_HashAlgorithmSHA256 : SHA256
     {
-
 
         /// <summary>
         /// The message digest context
@@ -7804,13 +7326,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA256"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_dll_HashAlgorithmSHA256()
         {
-
-
            var algorithm = "SHA256";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -7924,9 +7442,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -7934,7 +7450,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_1_1_dll_HashAlgorithmSHA256 : SHA256
     {
-
 
         /// <summary>
         /// The message digest context
@@ -7953,13 +7468,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA256"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_1_1_dll_HashAlgorithmSHA256()
         {
-
-
            var algorithm = "SHA256";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_1_1_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -8073,9 +7584,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -8083,7 +7592,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmSHA256 : SHA256
     {
-
 
         /// <summary>
         /// The message digest context
@@ -8102,13 +7610,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA256"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmSHA256()
         {
-
-
            var algorithm = "SHA256";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_1_1_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -8222,9 +7726,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -8232,7 +7734,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_x64_dll_HashAlgorithmSHA256 : SHA256
     {
-
 
         /// <summary>
         /// The message digest context
@@ -8251,13 +7752,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA256"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_x64_dll_HashAlgorithmSHA256()
         {
-
-
            var algorithm = "SHA256";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -8371,10 +7868,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
-
 
 
     /// <summary>
@@ -8382,7 +7876,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_HashAlgorithmSHA384 : SHA384
     {
-
 
         /// <summary>
         /// The message digest context
@@ -8401,13 +7894,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA384"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_HashAlgorithmSHA384()
         {
-
-
            var algorithm = "SHA384";
-
             m_digestmethod = InteropOpenSSL11_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -8521,9 +8010,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -8531,7 +8018,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_so_1_1_HashAlgorithmSHA384 : SHA384
     {
-
 
         /// <summary>
         /// The message digest context
@@ -8550,13 +8036,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA384"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_so_1_1_HashAlgorithmSHA384()
         {
-
-
            var algorithm = "SHA384";
-
             m_digestmethod = InteropOpenSSL11_libssl_so_1_1.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -8670,9 +8152,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -8680,7 +8160,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_so_1_1_0_HashAlgorithmSHA384 : SHA384
     {
-
 
         /// <summary>
         /// The message digest context
@@ -8699,13 +8178,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA384"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_so_1_1_0_HashAlgorithmSHA384()
         {
-
-
            var algorithm = "SHA384";
-
             m_digestmethod = InteropOpenSSL11_libssl_so_1_1_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -8819,9 +8294,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -8829,7 +8302,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_dll_HashAlgorithmSHA384 : SHA384
     {
-
 
         /// <summary>
         /// The message digest context
@@ -8848,13 +8320,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA384"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_dll_HashAlgorithmSHA384()
         {
-
-
            var algorithm = "SHA384";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -8968,9 +8436,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -8978,7 +8444,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_1_1_dll_HashAlgorithmSHA384 : SHA384
     {
-
 
         /// <summary>
         /// The message digest context
@@ -8997,13 +8462,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA384"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_1_1_dll_HashAlgorithmSHA384()
         {
-
-
            var algorithm = "SHA384";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_1_1_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -9117,9 +8578,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -9127,7 +8586,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmSHA384 : SHA384
     {
-
 
         /// <summary>
         /// The message digest context
@@ -9146,13 +8604,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA384"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmSHA384()
         {
-
-
            var algorithm = "SHA384";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_1_1_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -9266,9 +8720,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -9276,7 +8728,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_x64_dll_HashAlgorithmSHA384 : SHA384
     {
-
 
         /// <summary>
         /// The message digest context
@@ -9295,13 +8746,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA384"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_x64_dll_HashAlgorithmSHA384()
         {
-
-
            var algorithm = "SHA384";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -9415,10 +8862,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
-
 
 
     /// <summary>
@@ -9426,7 +8870,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_HashAlgorithmSHA512 : SHA512
     {
-
 
         /// <summary>
         /// The message digest context
@@ -9445,13 +8888,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA512"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_HashAlgorithmSHA512()
         {
-
-
            var algorithm = "SHA512";
-
             m_digestmethod = InteropOpenSSL11_libssl.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -9565,9 +9004,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -9575,7 +9012,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_so_1_1_HashAlgorithmSHA512 : SHA512
     {
-
 
         /// <summary>
         /// The message digest context
@@ -9594,13 +9030,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA512"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_so_1_1_HashAlgorithmSHA512()
         {
-
-
            var algorithm = "SHA512";
-
             m_digestmethod = InteropOpenSSL11_libssl_so_1_1.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -9714,9 +9146,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -9724,7 +9154,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libssl_so_1_1_0_HashAlgorithmSHA512 : SHA512
     {
-
 
         /// <summary>
         /// The message digest context
@@ -9743,13 +9172,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA512"/> class.
         /// </summary>
-
         public OpenSSL11_libssl_so_1_1_0_HashAlgorithmSHA512()
         {
-
-
            var algorithm = "SHA512";
-
             m_digestmethod = InteropOpenSSL11_libssl_so_1_1_0.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -9863,9 +9288,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -9873,7 +9296,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_dll_HashAlgorithmSHA512 : SHA512
     {
-
 
         /// <summary>
         /// The message digest context
@@ -9892,13 +9314,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA512"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_dll_HashAlgorithmSHA512()
         {
-
-
            var algorithm = "SHA512";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -10012,9 +9430,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -10022,7 +9438,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_1_1_dll_HashAlgorithmSHA512 : SHA512
     {
-
 
         /// <summary>
         /// The message digest context
@@ -10041,13 +9456,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA512"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_1_1_dll_HashAlgorithmSHA512()
         {
-
-
            var algorithm = "SHA512";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_1_1_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -10161,9 +9572,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -10171,7 +9580,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmSHA512 : SHA512
     {
-
 
         /// <summary>
         /// The message digest context
@@ -10190,13 +9598,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA512"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_1_1_x64_dll_HashAlgorithmSHA512()
         {
-
-
            var algorithm = "SHA512";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_1_1_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -10310,9 +9714,7 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
-
 
 
     /// <summary>
@@ -10320,7 +9722,6 @@ namespace FasterHashing
     /// </summary>
     public class OpenSSL11_libcrypto_x64_dll_HashAlgorithmSHA512 : SHA512
     {
-
 
         /// <summary>
         /// The message digest context
@@ -10339,13 +9740,9 @@ namespace FasterHashing
         /// <summary>
         /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL11HashAlgorithmSHA512"/> class.
         /// </summary>
-
         public OpenSSL11_libcrypto_x64_dll_HashAlgorithmSHA512()
         {
-
-
            var algorithm = "SHA512";
-
             m_digestmethod = InteropOpenSSL11_libcrypto_x64_dll.EVP_get_digestbyname(algorithm);
             if (m_digestmethod == IntPtr.Zero)
                 throw new ArgumentException($"No such algorithm: {algorithm}");
@@ -10459,11 +9856,6999 @@ namespace FasterHashing
 
             base.Dispose(disposing);
         }
-
     }
 
 
+    /// <summary>
+    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_HashAlgorithm : HashAlgorithm
+    {
 
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// </summary>
+        /// <param name="algorithm">The name of the hash algorithm to use.</param>
+        public OpenSSL30_libssl_HashAlgorithm(string algorithm)
+        {
+            m_digestmethod = InteropOpenSSL30_libssl.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_HashAlgorithm()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Creates a new hash algorithm using an OpenSSL30 implementation
+        /// </summary>
+        /// <param name-"name">The name of the algorithm to create</param>
+        public static new HashAlgorithm Create(string name)
+        {
+            if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_HashAlgorithmMD5();
+            if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_HashAlgorithmSHA1();
+            if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_HashAlgorithmSHA256();
+            if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_HashAlgorithmSHA384();
+            if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_HashAlgorithmSHA512();
+            try { return new OpenSSL30_libssl_HashAlgorithm(name); }
+            catch { }
+
+            return null;
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_so_3_HashAlgorithm : HashAlgorithm
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// </summary>
+        /// <param name="algorithm">The name of the hash algorithm to use.</param>
+        public OpenSSL30_libssl_so_3_HashAlgorithm(string algorithm)
+        {
+            m_digestmethod = InteropOpenSSL30_libssl_so_3.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_so_3.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_so_3_HashAlgorithm()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Creates a new hash algorithm using an OpenSSL30 implementation
+        /// </summary>
+        /// <param name-"name">The name of the algorithm to create</param>
+        public static new HashAlgorithm Create(string name)
+        {
+            if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_so_3_HashAlgorithmMD5();
+            if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_so_3_HashAlgorithmSHA1();
+            if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_so_3_HashAlgorithmSHA256();
+            if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_so_3_HashAlgorithmSHA384();
+            if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_so_3_HashAlgorithmSHA512();
+            try { return new OpenSSL30_libssl_so_3_HashAlgorithm(name); }
+            catch { }
+
+            return null;
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_so_HashAlgorithm : HashAlgorithm
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// </summary>
+        /// <param name="algorithm">The name of the hash algorithm to use.</param>
+        public OpenSSL30_libcrypto_so_HashAlgorithm(string algorithm)
+        {
+            m_digestmethod = InteropOpenSSL30_libcrypto_so.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_so.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_so_HashAlgorithm()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Creates a new hash algorithm using an OpenSSL30 implementation
+        /// </summary>
+        /// <param name-"name">The name of the algorithm to create</param>
+        public static new HashAlgorithm Create(string name)
+        {
+            if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_so_HashAlgorithmMD5();
+            if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_so_HashAlgorithmSHA1();
+            if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_so_HashAlgorithmSHA256();
+            if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_so_HashAlgorithmSHA384();
+            if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_so_HashAlgorithmSHA512();
+            try { return new OpenSSL30_libcrypto_so_HashAlgorithm(name); }
+            catch { }
+
+            return null;
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_so_3_HashAlgorithm : HashAlgorithm
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// </summary>
+        /// <param name="algorithm">The name of the hash algorithm to use.</param>
+        public OpenSSL30_libcrypto_so_3_HashAlgorithm(string algorithm)
+        {
+            m_digestmethod = InteropOpenSSL30_libcrypto_so_3.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_so_3.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_so_3_HashAlgorithm()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Creates a new hash algorithm using an OpenSSL30 implementation
+        /// </summary>
+        /// <param name-"name">The name of the algorithm to create</param>
+        public static new HashAlgorithm Create(string name)
+        {
+            if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_so_3_HashAlgorithmMD5();
+            if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_so_3_HashAlgorithmSHA1();
+            if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_so_3_HashAlgorithmSHA256();
+            if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_so_3_HashAlgorithmSHA384();
+            if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_so_3_HashAlgorithmSHA512();
+            try { return new OpenSSL30_libcrypto_so_3_HashAlgorithm(name); }
+            catch { }
+
+            return null;
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_3_dll_HashAlgorithm : HashAlgorithm
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// </summary>
+        /// <param name="algorithm">The name of the hash algorithm to use.</param>
+        public OpenSSL30_libssl_3_dll_HashAlgorithm(string algorithm)
+        {
+            m_digestmethod = InteropOpenSSL30_libssl_3_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_3_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_3_dll_HashAlgorithm()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Creates a new hash algorithm using an OpenSSL30 implementation
+        /// </summary>
+        /// <param name-"name">The name of the algorithm to create</param>
+        public static new HashAlgorithm Create(string name)
+        {
+            if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_3_dll_HashAlgorithmMD5();
+            if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_3_dll_HashAlgorithmSHA1();
+            if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_3_dll_HashAlgorithmSHA256();
+            if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_3_dll_HashAlgorithmSHA384();
+            if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_3_dll_HashAlgorithmSHA512();
+            try { return new OpenSSL30_libssl_3_dll_HashAlgorithm(name); }
+            catch { }
+
+            return null;
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_3_x64_dll_HashAlgorithm : HashAlgorithm
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// </summary>
+        /// <param name="algorithm">The name of the hash algorithm to use.</param>
+        public OpenSSL30_libssl_3_x64_dll_HashAlgorithm(string algorithm)
+        {
+            m_digestmethod = InteropOpenSSL30_libssl_3_x64_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_3_x64_dll_HashAlgorithm()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Creates a new hash algorithm using an OpenSSL30 implementation
+        /// </summary>
+        /// <param name-"name">The name of the algorithm to create</param>
+        public static new HashAlgorithm Create(string name)
+        {
+            if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_3_x64_dll_HashAlgorithmMD5();
+            if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA1();
+            if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA256();
+            if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA384();
+            if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA512();
+            try { return new OpenSSL30_libssl_3_x64_dll_HashAlgorithm(name); }
+            catch { }
+
+            return null;
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_3_dll_HashAlgorithm : HashAlgorithm
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// </summary>
+        /// <param name="algorithm">The name of the hash algorithm to use.</param>
+        public OpenSSL30_libcrypto_3_dll_HashAlgorithm(string algorithm)
+        {
+            m_digestmethod = InteropOpenSSL30_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_3_dll_HashAlgorithm()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Creates a new hash algorithm using an OpenSSL30 implementation
+        /// </summary>
+        /// <param name-"name">The name of the algorithm to create</param>
+        public static new HashAlgorithm Create(string name)
+        {
+            if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_3_dll_HashAlgorithmMD5();
+            if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA1();
+            if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA256();
+            if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA384();
+            if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA512();
+            try { return new OpenSSL30_libcrypto_3_dll_HashAlgorithm(name); }
+            catch { }
+
+            return null;
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of a hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_3_x64_dll_HashAlgorithm : HashAlgorithm
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> class.
+        /// </summary>
+        /// <param name="algorithm">The name of the hash algorithm to use.</param>
+        public OpenSSL30_libcrypto_3_x64_dll_HashAlgorithm(string algorithm)
+        {
+            m_digestmethod = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithm"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_3_x64_dll_HashAlgorithm()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Creates a new hash algorithm using an OpenSSL30 implementation
+        /// </summary>
+        /// <param name-"name">The name of the algorithm to create</param>
+        public static new HashAlgorithm Create(string name)
+        {
+            if (string.Equals("MD5", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmMD5();
+            if (string.Equals("SHA1", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA1();
+            if (string.Equals("SHA256", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA256();
+            if (string.Equals("SHA384", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA384();
+            if (string.Equals("SHA512", name, StringComparison.OrdinalIgnoreCase))
+                return new OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA512();
+            try { return new OpenSSL30_libcrypto_3_x64_dll_HashAlgorithm(name); }
+            catch { }
+
+            return null;
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_HashAlgorithmMD5 : MD5
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_HashAlgorithmMD5()
+        {
+           var algorithm = "MD5";
+            m_digestmethod = InteropOpenSSL30_libssl.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_HashAlgorithmMD5()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_so_3_HashAlgorithmMD5 : MD5
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_so_3_HashAlgorithmMD5()
+        {
+           var algorithm = "MD5";
+            m_digestmethod = InteropOpenSSL30_libssl_so_3.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_so_3.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_so_3_HashAlgorithmMD5()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_so_HashAlgorithmMD5 : MD5
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_so_HashAlgorithmMD5()
+        {
+           var algorithm = "MD5";
+            m_digestmethod = InteropOpenSSL30_libcrypto_so.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_so.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_so_HashAlgorithmMD5()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_so_3_HashAlgorithmMD5 : MD5
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_so_3_HashAlgorithmMD5()
+        {
+           var algorithm = "MD5";
+            m_digestmethod = InteropOpenSSL30_libcrypto_so_3.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_so_3.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_so_3_HashAlgorithmMD5()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_3_dll_HashAlgorithmMD5 : MD5
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_3_dll_HashAlgorithmMD5()
+        {
+           var algorithm = "MD5";
+            m_digestmethod = InteropOpenSSL30_libssl_3_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_3_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_3_dll_HashAlgorithmMD5()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_3_x64_dll_HashAlgorithmMD5 : MD5
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_3_x64_dll_HashAlgorithmMD5()
+        {
+           var algorithm = "MD5";
+            m_digestmethod = InteropOpenSSL30_libssl_3_x64_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_3_x64_dll_HashAlgorithmMD5()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_3_dll_HashAlgorithmMD5 : MD5
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_3_dll_HashAlgorithmMD5()
+        {
+           var algorithm = "MD5";
+            m_digestmethod = InteropOpenSSL30_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_3_dll_HashAlgorithmMD5()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the MD5 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmMD5 : MD5
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmMD5()
+        {
+           var algorithm = "MD5";
+            m_digestmethod = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmMD5"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmMD5()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_HashAlgorithmSHA1 : SHA1
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_HashAlgorithmSHA1()
+        {
+           var algorithm = "SHA1";
+            m_digestmethod = InteropOpenSSL30_libssl.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_HashAlgorithmSHA1()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_so_3_HashAlgorithmSHA1 : SHA1
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_so_3_HashAlgorithmSHA1()
+        {
+           var algorithm = "SHA1";
+            m_digestmethod = InteropOpenSSL30_libssl_so_3.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_so_3.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_so_3_HashAlgorithmSHA1()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_so_HashAlgorithmSHA1 : SHA1
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_so_HashAlgorithmSHA1()
+        {
+           var algorithm = "SHA1";
+            m_digestmethod = InteropOpenSSL30_libcrypto_so.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_so.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_so_HashAlgorithmSHA1()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_so_3_HashAlgorithmSHA1 : SHA1
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_so_3_HashAlgorithmSHA1()
+        {
+           var algorithm = "SHA1";
+            m_digestmethod = InteropOpenSSL30_libcrypto_so_3.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_so_3.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_so_3_HashAlgorithmSHA1()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_3_dll_HashAlgorithmSHA1 : SHA1
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_3_dll_HashAlgorithmSHA1()
+        {
+           var algorithm = "SHA1";
+            m_digestmethod = InteropOpenSSL30_libssl_3_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_3_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_3_dll_HashAlgorithmSHA1()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA1 : SHA1
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA1()
+        {
+           var algorithm = "SHA1";
+            m_digestmethod = InteropOpenSSL30_libssl_3_x64_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA1()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA1 : SHA1
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA1()
+        {
+           var algorithm = "SHA1";
+            m_digestmethod = InteropOpenSSL30_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA1()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA1 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA1 : SHA1
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA1()
+        {
+           var algorithm = "SHA1";
+            m_digestmethod = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA1"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA1()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_HashAlgorithmSHA256 : SHA256
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_HashAlgorithmSHA256()
+        {
+           var algorithm = "SHA256";
+            m_digestmethod = InteropOpenSSL30_libssl.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_HashAlgorithmSHA256()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_so_3_HashAlgorithmSHA256 : SHA256
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_so_3_HashAlgorithmSHA256()
+        {
+           var algorithm = "SHA256";
+            m_digestmethod = InteropOpenSSL30_libssl_so_3.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_so_3.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_so_3_HashAlgorithmSHA256()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_so_HashAlgorithmSHA256 : SHA256
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_so_HashAlgorithmSHA256()
+        {
+           var algorithm = "SHA256";
+            m_digestmethod = InteropOpenSSL30_libcrypto_so.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_so.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_so_HashAlgorithmSHA256()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_so_3_HashAlgorithmSHA256 : SHA256
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_so_3_HashAlgorithmSHA256()
+        {
+           var algorithm = "SHA256";
+            m_digestmethod = InteropOpenSSL30_libcrypto_so_3.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_so_3.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_so_3_HashAlgorithmSHA256()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_3_dll_HashAlgorithmSHA256 : SHA256
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_3_dll_HashAlgorithmSHA256()
+        {
+           var algorithm = "SHA256";
+            m_digestmethod = InteropOpenSSL30_libssl_3_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_3_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_3_dll_HashAlgorithmSHA256()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA256 : SHA256
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA256()
+        {
+           var algorithm = "SHA256";
+            m_digestmethod = InteropOpenSSL30_libssl_3_x64_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA256()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA256 : SHA256
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA256()
+        {
+           var algorithm = "SHA256";
+            m_digestmethod = InteropOpenSSL30_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA256()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA256 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA256 : SHA256
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA256()
+        {
+           var algorithm = "SHA256";
+            m_digestmethod = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA256"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA256()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_HashAlgorithmSHA384 : SHA384
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_HashAlgorithmSHA384()
+        {
+           var algorithm = "SHA384";
+            m_digestmethod = InteropOpenSSL30_libssl.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_HashAlgorithmSHA384()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_so_3_HashAlgorithmSHA384 : SHA384
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_so_3_HashAlgorithmSHA384()
+        {
+           var algorithm = "SHA384";
+            m_digestmethod = InteropOpenSSL30_libssl_so_3.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_so_3.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_so_3_HashAlgorithmSHA384()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_so_HashAlgorithmSHA384 : SHA384
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_so_HashAlgorithmSHA384()
+        {
+           var algorithm = "SHA384";
+            m_digestmethod = InteropOpenSSL30_libcrypto_so.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_so.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_so_HashAlgorithmSHA384()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_so_3_HashAlgorithmSHA384 : SHA384
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_so_3_HashAlgorithmSHA384()
+        {
+           var algorithm = "SHA384";
+            m_digestmethod = InteropOpenSSL30_libcrypto_so_3.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_so_3.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_so_3_HashAlgorithmSHA384()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_3_dll_HashAlgorithmSHA384 : SHA384
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_3_dll_HashAlgorithmSHA384()
+        {
+           var algorithm = "SHA384";
+            m_digestmethod = InteropOpenSSL30_libssl_3_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_3_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_3_dll_HashAlgorithmSHA384()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA384 : SHA384
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA384()
+        {
+           var algorithm = "SHA384";
+            m_digestmethod = InteropOpenSSL30_libssl_3_x64_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA384()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA384 : SHA384
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA384()
+        {
+           var algorithm = "SHA384";
+            m_digestmethod = InteropOpenSSL30_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA384()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA384 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA384 : SHA384
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA384()
+        {
+           var algorithm = "SHA384";
+            m_digestmethod = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA384"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA384()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_HashAlgorithmSHA512 : SHA512
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_HashAlgorithmSHA512()
+        {
+           var algorithm = "SHA512";
+            m_digestmethod = InteropOpenSSL30_libssl.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_HashAlgorithmSHA512()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_so_3_HashAlgorithmSHA512 : SHA512
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_so_3_HashAlgorithmSHA512()
+        {
+           var algorithm = "SHA512";
+            m_digestmethod = InteropOpenSSL30_libssl_so_3.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_so_3.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_so_3.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_so_3_HashAlgorithmSHA512()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_so_3.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_so_HashAlgorithmSHA512 : SHA512
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_so_HashAlgorithmSHA512()
+        {
+           var algorithm = "SHA512";
+            m_digestmethod = InteropOpenSSL30_libcrypto_so.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_so.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_so.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_so.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_so.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_so_HashAlgorithmSHA512()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_so.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_so_3_HashAlgorithmSHA512 : SHA512
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_so_3_HashAlgorithmSHA512()
+        {
+           var algorithm = "SHA512";
+            m_digestmethod = InteropOpenSSL30_libcrypto_so_3.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_so_3.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_so_3.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_so_3.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_so_3.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_so_3_HashAlgorithmSHA512()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_so_3.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_3_dll_HashAlgorithmSHA512 : SHA512
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_3_dll_HashAlgorithmSHA512()
+        {
+           var algorithm = "SHA512";
+            m_digestmethod = InteropOpenSSL30_libssl_3_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_3_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_3_dll_HashAlgorithmSHA512()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_3_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA512 : SHA512
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
+        /// </summary>
+        public OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA512()
+        {
+           var algorithm = "SHA512";
+            m_digestmethod = InteropOpenSSL30_libssl_3_x64_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libssl_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libssl_3_x64_dll_HashAlgorithmSHA512()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libssl_3_x64_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA512 : SHA512
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA512()
+        {
+           var algorithm = "SHA512";
+            m_digestmethod = InteropOpenSSL30_libcrypto_3_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_3_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_3_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_3_dll_HashAlgorithmSHA512()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_3_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+
+
+    /// <summary>
+    /// Implementation of the SHA512 hash algorithm, using OpenSSL 3.0
+    /// </summary>
+    public class OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA512 : SHA512
+    {
+
+        /// <summary>
+        /// The message digest context
+        /// </summary>
+        private IntPtr m_context;
+
+        /// <summary>
+        /// The size of the message digest
+        /// </summary>
+        private readonly int m_size;
+        /// <summary>
+        /// The message digest method
+        /// </summary>
+        private readonly IntPtr m_digestmethod;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> class.
+        /// </summary>
+        public OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA512()
+        {
+           var algorithm = "SHA512";
+            m_digestmethod = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_get_digestbyname(algorithm);
+            if (m_digestmethod == IntPtr.Zero)
+                throw new ArgumentException($"No such algorithm: {algorithm}");
+
+            m_size = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_size(m_digestmethod);
+        }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int OutputBlockSize { get { return m_size; } }
+
+        /// <summary>
+        /// Gets the size of the message digest in bytes
+        /// </summary>
+        public override int InputBlockSize { get { return InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_block_size(m_digestmethod); } }
+
+        /// <summary>
+        /// Initializes the hashing algorithm
+        /// </summary>
+        public override void Initialize()
+        {
+            if (m_context != IntPtr.Zero)
+                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+            m_context = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_new();
+
+            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestInit_ex(m_context, m_digestmethod, IntPtr.Zero) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+        }
+
+        /// <summary>
+        /// Performs the core hashing
+        /// </summary>
+        /// <param name="array">The data to hash.</param>
+        /// <param name="ibStart">The index into the array where hashing starts.</param>
+        /// <param name="cbSize">The number of bytes to hash.</param>
+        protected override void HashCore(byte[] array, int ibStart, int cbSize)
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            // Common case is to use offset=0, and here we can rely on the system marshaller to work
+            if (ibStart == 0)
+            {
+                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, array, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#if AVOID_PINNING_SMALL_ARRAYS
+            // For small chunks, we can copy and get mostly the same performance as the managed version
+            else if (cbSize < 1024)
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+
+                var tmp = new byte[cbSize];
+                Array.Copy(array, ibStart, tmp, 0, cbSize);
+                if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, tmp, (uint)cbSize) != 1)
+                    throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+#endif
+            // Otherwise, the fastest is obtaining a pinned pointer and adding the offset to that
+            else
+            {
+                System.Diagnostics.Trace.WriteLineIf(!ErrorStateHelper.HasReportedOffsetIssue, "Warning, using arrays with non-zero offset provides significantly slower hashing performance");
+                ErrorStateHelper.HasReportedOffsetIssue = true;
+                var pa = GCHandle.Alloc(array, GCHandleType.Pinned);
+                var res = InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestUpdate(m_context, Marshal.UnsafeAddrOfPinnedArrayElement(array, ibStart), (uint)cbSize);
+                pa.Free();
+                if (res != 1)
+                   throw new Win32Exception(Marshal.GetLastWin32Error());
+           }
+        }
+
+        /// <summary>
+        /// Computes the final hash and returns the result
+        /// </summary>
+        /// <returns>The final messge digest.</returns>
+        protected override byte[] HashFinal()
+        {
+            if (m_context == IntPtr.Zero)
+                Initialize();
+
+            var res = new byte[m_size];
+            var rs = (uint)m_size;
+            if (InteropOpenSSL30_libcrypto_3_x64_dll.EVP_DigestFinal_ex(m_context, res, ref rs) != 1)
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            return res;
+        }
+
+        /// <summary>
+        /// Releases unmanaged resources and performs other cleanup operations before the
+        /// <see cref="T:FasterHashing.OpenSSL30HashAlgorithmSHA512"/> is reclaimed by garbage collection.
+        /// </summary>
+        ~OpenSSL30_libcrypto_3_x64_dll_HashAlgorithmSHA512()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Dispose the this instance.
+        /// </summary>
+        /// <param name="disposing">If set to <c>true</c> this is called from <see cref="Dispose"/>.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_context != IntPtr.Zero)
+            {
+                InteropOpenSSL30_libcrypto_3_x64_dll.EVP_MD_CTX_free(m_context);
+                m_context = IntPtr.Zero;
+            }
+
+            base.Dispose(disposing);
+        }
+    }
 
 
 

--- a/FasterHashing/OpenSSLImplementations.tt
+++ b/FasterHashing/OpenSSLImplementations.tt
@@ -11,19 +11,19 @@ using System.Security.Cryptography;
 namespace FasterHashing
 {
 <# 
-  var libs = new[] { "OpenSSL10", "OpenSSL11", "OpenSSL30" };
+  var libs = new[] { "OpenSSL10", "OpenSSL11", "OpenSSL3" };
   var algs = new[] { null, "MD5", "SHA1", "SHA256", "SHA384", "SHA512" };
   var libnames_10 = new [] { "libssl", "libssl.so.1.0", "libssl.so.1.0.0", "libeay32.dll" };
   var libnames_11 = new [] { "libssl", "libssl.so.1.1", "libssl.so.1.1.0", "libcrypto.dll", "libcrypto-1_1.dll", "libcrypto-1_1-x64.dll", "libcrypto-x64.dll" };
   
   // OPENSSL >=1.1: naming scheme for windows is libcrypto-x_x.dll - we still keep libcrypto.dll until LIBRESSL support is complete 
   // var libnames_11 = new [] { "libssl", "libssl.so.1.1", "libssl.so.1.1.0", "libcrypto-1_1.dll", "libcrypto-1_1-x64.dll" };
-  var libnames_30 = new [] { "libssl", "libssl.so.3", "libcrypto.so", "libcrypto.so.3","libssl-3.dll", "libssl-3-x64.dll","libcrypto-3.dll", "libcrypto-3-x64.dll"  };
+  var libnames_3 = new [] { "libssl", "libssl.so.3", "libcrypto.so", "libcrypto.so.3","libcrypto-3.dll", "libcrypto-3-x64.dll"  };
 
 
   foreach(var lib in libs) {
   foreach(var alg in algs) {
-  foreach(var _soname in (lib == "OpenSSL10" ? libnames_10 : lib == "OpenSSL11" ? libnames_11 : libnames_30)) {
+  foreach(var _soname in (lib == "OpenSSL10" ? libnames_10 : lib == "OpenSSL11" ? libnames_11 : libnames_3)) {
 
     var destroy = lib == "OpenSSL10" ? "destroy" : "free";
     var cleanup = lib == "OpenSSL10" ? "cleanup" : "reset";
@@ -34,7 +34,7 @@ namespace FasterHashing
 
 #>
     /// <summary>
-    /// Implementation of <#= alg == null ? "a" : "the " + alg #> hash algorithm, using OpenSSL <#= lib == "OpenSSL10" ? "1.0" : lib == "OpenSSL11" ? "1.1" : "3.0" #>
+    /// Implementation of <#= alg == null ? "a" : "the " + alg #> hash algorithm, using OpenSSL <#= lib == "OpenSSL10" ? "1.0" : lib == "OpenSSL11" ? "1.1" : "3" #>
     /// </summary>
     public class <#= lib #>_<#= soname #>_HashAlgorithm<#= alg ?? "" #> : <#= alg ?? "HashAlgorithm" #>
     {

--- a/FasterHashing/OpenSSLImplementations.tt
+++ b/FasterHashing/OpenSSLImplementations.tt
@@ -11,14 +11,19 @@ using System.Security.Cryptography;
 namespace FasterHashing
 {
 <# 
-  var libs = new[] { "OpenSSL10", "OpenSSL11" };
+  var libs = new[] { "OpenSSL10", "OpenSSL11", "OpenSSL30" };
   var algs = new[] { null, "MD5", "SHA1", "SHA256", "SHA384", "SHA512" };
   var libnames_10 = new [] { "libssl", "libssl.so.1.0", "libssl.so.1.0.0", "libeay32.dll" };
   var libnames_11 = new [] { "libssl", "libssl.so.1.1", "libssl.so.1.1.0", "libcrypto.dll", "libcrypto-1_1.dll", "libcrypto-1_1-x64.dll", "libcrypto-x64.dll" };
+  
+  // OPENSSL >=1.1: naming scheme for windows is libcrypto-x_x.dll - we still keep libcrypto.dll until LIBRESSL support is complete 
+  // var libnames_11 = new [] { "libssl", "libssl.so.1.1", "libssl.so.1.1.0", "libcrypto-1_1.dll", "libcrypto-1_1-x64.dll" };
+  var libnames_30 = new [] { "libssl", "libssl.so.3", "libcrypto.so", "libcrypto.so.3","libssl-3.dll", "libssl-3-x64.dll","libcrypto-3.dll", "libcrypto-3-x64.dll"  };
+
 
   foreach(var lib in libs) {
   foreach(var alg in algs) {
-  foreach(var _soname in (lib == "OpenSSL10" ? libnames_10 : libnames_11)) {
+  foreach(var _soname in (lib == "OpenSSL10" ? libnames_10 : lib == "OpenSSL11" ? libnames_11 : libnames_30)) {
 
     var destroy = lib == "OpenSSL10" ? "destroy" : "free";
     var cleanup = lib == "OpenSSL10" ? "cleanup" : "reset";
@@ -29,7 +34,7 @@ namespace FasterHashing
 
 #>
     /// <summary>
-    /// Implementation of <#= alg == null ? "a" : "the " + alg #> hash algorithm, using OpenSSL <#= lib == "OpenSSL10" ? "1.0" : "1.1" #>
+    /// Implementation of <#= alg == null ? "a" : "the " + alg #> hash algorithm, using OpenSSL <#= lib == "OpenSSL10" ? "1.0" : lib == "OpenSSL11" ? "1.1" : "3.0" #>
     /// </summary>
     public class <#= lib #>_<#= soname #>_HashAlgorithm<#= alg ?? "" #> : <#= alg ?? "HashAlgorithm" #>
     {

--- a/FasterHashing/Properties/AssemblyInfo.cs
+++ b/FasterHashing/Properties/AssemblyInfo.cs
@@ -17,7 +17,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("1.1.2.*")]
+[assembly: AssemblyVersion("1.3.0.*")]
 
 // The following attributes are used to specify the signing key for the assembly, 
 // if desired. See the Mono documentation for more information about signing.

--- a/FasterHashingTester/FasterHashingTester.csproj
+++ b/FasterHashingTester/FasterHashingTester.csproj
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -7,9 +7,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>FasterHashingTester</RootNamespace>
     <AssemblyName>FasterHashingTester</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <Prefer32Bit>false</Prefer32Bit>
     <ReleaseVersion>1.3.0</ReleaseVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
@@ -59,6 +60,9 @@
       <Project>{C70E5674-432A-4319-B639-A320885B3476}</Project>
       <Name>FasterHashing</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
With _OpenSSL3_-API, changes to library-exports were introduced effectively breaking _FasterHashing_:
`EVP_MD_size` which is/was an alias for `EVP_MD_get_size` was removed as exposed function. 
The alias is still defined in the interface-header, but as _FasterHashing_ directly imports from the libs, the alias is no longer visible.
See duplicati-issue [#4716](https://github.com/duplicati/duplicati/issues/4716).

This patch:

- Adds additional detection for OpenSSL3 libraries.
- Improves API-identification by **evaluating** the `OpenSSL_version` string
 for OpenSSL1.1, LibreSSL and OpenSSL3.
- Remaps  `EVP_MD_get_size` -> `EVP_MD_size` for OpenSSL3.
- Raises assembly-version to 1.3.0

br umgfoin.
